### PR TITLE
feat: add Soroban event service for activity feed

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -31,6 +31,11 @@ NEXT_PUBLIC_STACKS_API_URL=https://api.testnet.hiro.so
 NEXT_PUBLIC_CONTRACT_ADDRESS=ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
 NEXT_PUBLIC_CONTRACT_NAME=predinex-pool
 
+# Soroban Contract ID - the deployed Soroban contract on Stellar (C... strkey format)
+# Required for the Soroban event service (activity feed)
+# Testnet example: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
+NEXT_PUBLIC_SOROBAN_CONTRACT_ID=
+
 # =============================================================================
 # DEVELOPMENT ONLY
 # =============================================================================

--- a/web/DEVELOPMENT.md
+++ b/web/DEVELOPMENT.md
@@ -73,6 +73,31 @@ When working on features that touch the smart contract interface:
 - **Versioning & migrations** — All contract changes (breaking or otherwise) must follow the process in [docs/CONTRACT_VERSIONING.md](./docs/CONTRACT_VERSIONING.md). Breaking interface changes require an explicit major version bump and a migration note before the PR can be merged.
 - **Error boundaries** — Route-level components should be wrapped in `<RouteErrorBoundary routeName="...">` (see `web/components/RouteErrorBoundary.tsx`). Add the wrapper when creating new top-level pages.
 
+## Soroban Event Service (Activity Feed)
+
+The activity feed is powered by `web/app/lib/soroban-event-service.ts`, which ingests Soroban contract events directly from the Stellar RPC.
+
+### How it works
+
+1. `getUserActivityFromSoroban` calls the Soroban RPC `getEvents` method, filtering by contract ID and relevant event names (`place_bet`, `claim_winnings`, `create_pool`, `settle_pool`).
+2. `decodeSorobanEvent` normalises raw RPC topic/value payloads into typed `DecodedSorobanEvent` objects.
+3. `mapEventToActivityItem` converts decoded events into `ActivityItem` objects consumed by `<ActivityFeed>`.
+4. `useUserActivity` (hook) calls `predinexReadApi.getUserActivitySoroban` which wires the above together.
+
+### Local environment setup
+
+Add the following to your `.env.local`:
+
+```env
+NEXT_PUBLIC_SOROBAN_CONTRACT_ID=<your-deployed-contract-C-strkey>
+```
+
+The Soroban RPC URL defaults to `https://soroban-testnet.stellar.org` for testnet and `https://mainnet.stellar.validationcloud.io/v1/soroban/rpc` for mainnet (configured in `walletconnect-config.ts`).
+
+### Deployed environment
+
+Set `NEXT_PUBLIC_SOROBAN_CONTRACT_ID` to the mainnet contract strkey in your deployment environment variables. The RPC URL is resolved automatically based on `NEXT_PUBLIC_NETWORK`.
+
 ## Testing
 
 ### Local CI/CD Checks

--- a/web/app/hooks/useUserActivity.ts
+++ b/web/app/hooks/useUserActivity.ts
@@ -13,6 +13,7 @@ interface UseUserActivityReturn {
 
 /**
  * Hook to fetch and manage a user's on-chain activity feed.
+ * Uses the Soroban event service to ingest contract events from Stellar.
  * Automatically fetches when an address is provided.
  */
 export function useUserActivity(
@@ -33,7 +34,7 @@ export function useUserActivity(
         setError(null);
 
         try {
-            const data = await predinexReadApi.getUserActivity(address, limit);
+            const data = await predinexReadApi.getUserActivitySoroban(address, limit);
             setActivities(data);
         } catch (e) {
             setError('Failed to load activity. Please try again.');

--- a/web/app/lib/adapters/index.ts
+++ b/web/app/lib/adapters/index.ts
@@ -5,3 +5,9 @@ export {
   fetchPredinexContractEvents,
 } from './predinex-read-api';
 export type { Pool, ActivityItem } from './types';
+export {
+  getUserActivityFromSoroban,
+  decodeSorobanEvent,
+  mapEventToActivityItem,
+} from '../soroban-event-service';
+export type { SorobanEventServiceConfig, DecodedSorobanEvent, SorobanEventName } from '../soroban-event-service';

--- a/web/app/lib/adapters/predinex-read-api.ts
+++ b/web/app/lib/adapters/predinex-read-api.ts
@@ -10,6 +10,8 @@ import {
   getMarkets,
   getUserActivity,
 } from '../stacks-api';
+import { getUserActivityFromSoroban } from '../soroban-event-service';
+import type { ActivityItem } from './types';
 
 export function getStacksCoreApiBaseUrl(): string {
   return getRuntimeConfig().api.coreApiUrl;
@@ -25,10 +27,29 @@ export async function fetchPredinexContractEvents(limit: number): Promise<{
   return response.json();
 }
 
+/**
+ * Fetches user activity via the Soroban event pipeline.
+ * Falls back to an empty array if the Soroban contract ID is not configured.
+ */
+async function getUserActivitySoroban(
+  address: string,
+  limit: number
+): Promise<ActivityItem[]> {
+  const cfg = getRuntimeConfig();
+  const { soroban } = cfg;
+  return getUserActivityFromSoroban(address, limit, {
+    rpcUrl: soroban.rpcUrl,
+    explorerUrl: soroban.explorerUrl,
+    contractId: soroban.contractId,
+  });
+}
+
 export const predinexReadApi = {
   getPool,
   getUserBet,
   getTotalVolume,
   getMarkets,
+  /** @deprecated Use getUserActivitySoroban — kept for backwards compat */
   getUserActivity,
+  getUserActivitySoroban,
 };

--- a/web/app/lib/runtime-config.ts
+++ b/web/app/lib/runtime-config.ts
@@ -22,10 +22,20 @@ export type StacksApiConfig = {
   rpcUrl: string;
 };
 
+export type SorobanConfig = {
+  /** Soroban RPC URL used for getEvents and other Soroban RPC calls. */
+  rpcUrl: string;
+  /** Stellar explorer base URL (for linking to transactions). */
+  explorerUrl: string;
+  /** Deployed Soroban contract ID (C... strkey). */
+  contractId: string;
+};
+
 export type RuntimeConfig = {
   network: SupportedNetwork;
   contract: ContractConfig;
   api: StacksApiConfig;
+  soroban: SorobanConfig;
 };
 
 function getRequiredEnv(name: string): string {
@@ -75,6 +85,15 @@ export function getRuntimeConfig(): RuntimeConfig {
     throw new Error(`Missing Stacks API URLs for network '${network}' in wallet configuration.`);
   }
 
+  const sorobanNet = WALLETCONNECT_CONFIG.soroban[network];
+  if (!sorobanNet?.rpcUrl || !sorobanNet?.explorerUrl) {
+    throw new Error(`Missing Soroban RPC URLs for network '${network}' in wallet configuration.`);
+  }
+
+  // Soroban contract ID — prefer explicit env var, fall back to analytics config
+  const sorobanContractId =
+    (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_SOROBAN_CONTRACT_ID) || '';
+
   const analyticsKey = network === 'mainnet' ? 'MAINNET' : 'TESTNET';
   const contractIdFromAnalytics = (ANALYTICS_NETWORK_CONFIG as any)?.[analyticsKey]?.CONTRACT_ADDRESS;
   if (!contractIdFromAnalytics || typeof contractIdFromAnalytics !== 'string') {
@@ -97,6 +116,11 @@ export function getRuntimeConfig(): RuntimeConfig {
       coreApiUrl: walletNet.coreApiUrl,
       explorerUrl: walletNet.explorerUrl,
       rpcUrl: walletNet.rpcUrl,
+    },
+    soroban: {
+      rpcUrl: sorobanNet.rpcUrl,
+      explorerUrl: sorobanNet.explorerUrl,
+      contractId: sorobanContractId,
     },
   };
 

--- a/web/app/lib/soroban-event-service.ts
+++ b/web/app/lib/soroban-event-service.ts
@@ -1,0 +1,373 @@
+/**
+ * Soroban Event Service
+ *
+ * Fetches and maps Soroban contract events from the Stellar RPC / Horizon API
+ * into typed ActivityItem objects consumed by the UI.
+ *
+ * Event schema reference: web/docs/CONTRACT_EVENTS.md
+ */
+
+import type { ActivityItem } from './adapters/types';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface SorobanEventServiceConfig {
+  /** Soroban RPC URL, e.g. https://soroban-testnet.stellar.org */
+  rpcUrl: string;
+  /** Stellar explorer base URL for building tx links */
+  explorerUrl: string;
+  /** Deployed contract ID (Stellar strkey C... format) */
+  contractId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Raw Soroban event shapes (from RPC getEvents response)
+// ---------------------------------------------------------------------------
+
+interface RawSorobanEvent {
+  /** Hex-encoded ledger sequence + tx index, used as a stable ID */
+  id: string;
+  /** Ledger close time as Unix timestamp (seconds) */
+  ledgerClosedAt?: string;
+  /** Ledger sequence number */
+  ledger?: number;
+  /** Transaction hash */
+  txHash?: string;
+  /** Decoded topic values as XDR base64 strings or native JS values */
+  topic: unknown[];
+  /** Decoded data value */
+  value: unknown;
+  /** Contract ID that emitted the event */
+  contractId?: string;
+}
+
+interface GetEventsResponse {
+  result?: {
+    events?: RawSorobanEvent[];
+    latestLedger?: number;
+  };
+  error?: { message: string };
+}
+
+// ---------------------------------------------------------------------------
+// Typed event payloads (after decoding)
+// ---------------------------------------------------------------------------
+
+export type SorobanEventName =
+  | 'create_pool'
+  | 'place_bet'
+  | 'settle_pool'
+  | 'claim_winnings'
+  | 'fee_collected'
+  | 'treasury_withdrawal';
+
+export interface DecodedSorobanEvent {
+  name: SorobanEventName;
+  poolId?: number;
+  user?: string;
+  /** Raw token units (i128 stored as number for JS compat) */
+  amount?: number;
+  outcome?: 0 | 1;
+  winnings?: number;
+  winningOutcome?: 0 | 1;
+  txHash: string;
+  timestamp: number;
+  ledger?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Decoding helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Soroban RPC returns topic/value as either:
+ *  - A plain JS primitive (when the SDK decodes it)
+ *  - An object like { type: "symbol", value: "place_bet" }
+ *  - An XDR base64 string (raw mode)
+ *
+ * This helper normalises all three into a plain JS value.
+ */
+function scValToNative(raw: unknown): unknown {
+  if (raw === null || raw === undefined) return undefined;
+  if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') return raw;
+  if (typeof raw === 'bigint') return Number(raw);
+
+  if (typeof raw === 'object') {
+    const obj = raw as Record<string, unknown>;
+    // { type: "symbol" | "u32" | "i128" | "address" | ..., value: ... }
+    if ('value' in obj) return scValToNative(obj['value']);
+    // { _type: ..., _value: ... } (some SDK versions)
+    if ('_value' in obj) return scValToNative(obj['_value']);
+  }
+
+  return String(raw);
+}
+
+function toNumber(raw: unknown): number | undefined {
+  const v = scValToNative(raw);
+  if (v === undefined || v === null) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function toString(raw: unknown): string | undefined {
+  const v = scValToNative(raw);
+  if (typeof v === 'string' && v.length > 0) return v;
+  return undefined;
+}
+
+/**
+ * Decode a raw Soroban event into a typed DecodedSorobanEvent.
+ * Returns null if the event name is unrecognised or topics are malformed.
+ */
+export function decodeSorobanEvent(raw: RawSorobanEvent): DecodedSorobanEvent | null {
+  const topics = raw.topic ?? [];
+  if (topics.length === 0) return null;
+
+  const name = toString(topics[0]) as SorobanEventName | undefined;
+  if (!name) return null;
+
+  const txHash = raw.txHash ?? raw.id ?? '';
+  const timestamp = raw.ledgerClosedAt
+    ? Math.floor(new Date(raw.ledgerClosedAt).getTime() / 1000)
+    : Math.floor(Date.now() / 1000);
+
+  const base: DecodedSorobanEvent = { name, txHash, timestamp, ledger: raw.ledger };
+
+  switch (name) {
+    case 'create_pool': {
+      // topics: [name, pool_id], data: creator
+      base.poolId = toNumber(topics[1]);
+      return base;
+    }
+
+    case 'place_bet': {
+      // topics: [name, pool_id, user], data: (outcome, amount)
+      base.poolId = toNumber(topics[1]);
+      base.user = toString(topics[2]);
+      // data is a tuple [outcome, amount]
+      const data = raw.value;
+      if (Array.isArray(data)) {
+        const outcome = toNumber(data[0]);
+        base.outcome = (outcome === 0 || outcome === 1) ? outcome : undefined;
+        base.amount = toNumber(data[1]);
+      } else if (data && typeof data === 'object') {
+        const d = data as Record<string, unknown>;
+        const outcome = toNumber(d['outcome'] ?? d[0]);
+        base.outcome = (outcome === 0 || outcome === 1) ? outcome : undefined;
+        base.amount = toNumber(d['amount'] ?? d[1]);
+      }
+      return base;
+    }
+
+    case 'settle_pool': {
+      // topics: [name, pool_id], data: winning_outcome
+      base.poolId = toNumber(topics[1]);
+      const wo = toNumber(raw.value);
+      base.winningOutcome = (wo === 0 || wo === 1) ? wo : undefined;
+      return base;
+    }
+
+    case 'claim_winnings': {
+      // topics: [name, pool_id, user], data: winnings
+      base.poolId = toNumber(topics[1]);
+      base.user = toString(topics[2]);
+      base.winnings = toNumber(raw.value);
+      return base;
+    }
+
+    case 'fee_collected':
+    case 'treasury_withdrawal':
+      // Not surfaced in the activity feed
+      return null;
+
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event → ActivityItem mapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a decoded Soroban event to the ActivityItem UI model.
+ * Returns null for event types that don't map to a user-visible activity.
+ */
+export function mapEventToActivityItem(
+  event: DecodedSorobanEvent,
+  explorerUrl: string
+): ActivityItem | null {
+  const txUrl = `${explorerUrl}/tx/${event.txHash}`;
+
+  switch (event.name) {
+    case 'place_bet':
+      return {
+        txId: event.txHash,
+        type: 'bet-placed',
+        functionName: 'place_bet',
+        timestamp: event.timestamp,
+        status: 'success',
+        amount: event.amount,
+        poolId: event.poolId,
+        explorerUrl: txUrl,
+        event: {
+          type: 'bet',
+          poolId: event.poolId,
+          amount: event.amount,
+          outcome: event.outcome,
+        },
+      };
+
+    case 'claim_winnings':
+      return {
+        txId: event.txHash,
+        type: 'winnings-claimed',
+        functionName: 'claim_winnings',
+        timestamp: event.timestamp,
+        status: 'success',
+        amount: event.winnings,
+        poolId: event.poolId,
+        explorerUrl: txUrl,
+        event: {
+          type: 'claim',
+          poolId: event.poolId,
+          winnerAmount: event.winnings,
+        },
+      };
+
+    case 'create_pool':
+      return {
+        txId: event.txHash,
+        type: 'pool-created',
+        functionName: 'create_pool',
+        timestamp: event.timestamp,
+        status: 'success',
+        poolId: event.poolId,
+        explorerUrl: txUrl,
+        event: {
+          type: 'pool-creation',
+          poolId: event.poolId,
+        },
+      };
+
+    case 'settle_pool':
+      return {
+        txId: event.txHash,
+        type: 'contract-call',
+        functionName: 'settle_pool',
+        timestamp: event.timestamp,
+        status: 'success',
+        poolId: event.poolId,
+        explorerUrl: txUrl,
+        event: {
+          type: 'settlement',
+          poolId: event.poolId,
+          outcome: event.winningOutcome,
+        },
+      };
+
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main service function
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches Soroban contract events for a specific user address and maps them
+ * into ActivityItem objects for the UI.
+ *
+ * Queries the Soroban RPC `getEvents` method, filtering by contract ID and
+ * the user's address in the topic list (for place_bet and claim_winnings).
+ *
+ * @param userAddress - Stellar address (G... strkey) of the user
+ * @param limit       - Maximum number of activity items to return
+ * @param config      - Injectable service config (enables test isolation)
+ */
+export async function getUserActivityFromSoroban(
+  userAddress: string,
+  limit: number = 20,
+  config: SorobanEventServiceConfig
+): Promise<ActivityItem[]> {
+  const { rpcUrl, explorerUrl, contractId } = config;
+
+  if (!rpcUrl || !explorerUrl || !contractId) return [];
+
+  try {
+    // Use getEvents RPC method — filter by contract, user-relevant event names
+    const body = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'getEvents',
+      params: {
+        filters: [
+          {
+            type: 'contract',
+            contractIds: [contractId],
+            // Filter for events where the user address appears in topics
+            // (place_bet and claim_winnings include user in topic[2])
+            topics: [
+              ['place_bet', 'claim_winnings', 'create_pool', 'settle_pool'],
+            ],
+          },
+        ],
+        pagination: { limit },
+      },
+    };
+
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      console.error(`Soroban RPC error: ${response.status}`);
+      return [];
+    }
+
+    const json: GetEventsResponse = await response.json();
+
+    if (json.error) {
+      console.error('Soroban RPC returned error:', json.error.message);
+      return [];
+    }
+
+    const rawEvents: RawSorobanEvent[] = json.result?.events ?? [];
+
+    const items: ActivityItem[] = [];
+
+    for (const raw of rawEvents) {
+      const decoded = decodeSorobanEvent(raw);
+      if (!decoded) continue;
+
+      // Filter to events relevant to this user:
+      // - place_bet / claim_winnings must have user in topics
+      // - create_pool / settle_pool are included if the user is the creator
+      //   (we can't filter server-side without an indexer, so we include all
+      //    and let the UI decide; for user-specific feeds the hook can filter)
+      const isUserEvent =
+        decoded.user === userAddress ||
+        decoded.name === 'create_pool' ||
+        decoded.name === 'settle_pool';
+
+      if (!isUserEvent) continue;
+
+      const item = mapEventToActivityItem(decoded, explorerUrl);
+      if (item) items.push(item);
+    }
+
+    // Sort newest first
+    items.sort((a, b) => b.timestamp - a.timestamp);
+
+    return items.slice(0, limit);
+  } catch (e) {
+    console.error('Failed to fetch Soroban activity events:', e);
+    return [];
+  }
+}

--- a/web/app/lib/walletconnect-config.ts
+++ b/web/app/lib/walletconnect-config.ts
@@ -33,6 +33,18 @@ export const WALLETCONNECT_CONFIG = {
     },
   },
 
+  // Stellar / Soroban RPC endpoints (used by the Soroban event service)
+  soroban: {
+    mainnet: {
+      rpcUrl: 'https://mainnet.stellar.validationcloud.io/v1/soroban/rpc',
+      explorerUrl: 'https://stellar.expert/explorer/public',
+    },
+    testnet: {
+      rpcUrl: 'https://soroban-testnet.stellar.org',
+      explorerUrl: 'https://stellar.expert/explorer/testnet',
+    },
+  },
+
   // Supported wallet methods
   methods: [
     'stx_call_read_only',

--- a/web/tests/lib/soroban-event-service.test.ts
+++ b/web/tests/lib/soroban-event-service.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    decodeSorobanEvent,
+    mapEventToActivityItem,
+    getUserActivityFromSoroban,
+} from '../../app/lib/soroban-event-service';
+import type { SorobanEventServiceConfig } from '../../app/lib/soroban-event-service';
+
+global.fetch = vi.fn();
+
+const TEST_CONFIG: SorobanEventServiceConfig = {
+    rpcUrl: 'https://soroban-testnet.stellar.org',
+    explorerUrl: 'https://stellar.expert/explorer/testnet',
+    contractId: 'CTEST123CONTRACT',
+};
+
+const USER_ADDRESS = 'GBUSER123STELLARADDRESS';
+
+// Representative raw Soroban events (as returned by getEvents RPC)
+const RAW_PLACE_BET_EVENT = {
+    id: 'ledger-001',
+    txHash: '0xabc123',
+    ledgerClosedAt: '2024-01-15T10:00:00Z',
+    ledger: 100,
+    contractId: 'CTEST123CONTRACT',
+    topic: [
+        { type: 'symbol', value: 'place_bet' },
+        { type: 'u32', value: 5 },
+        { type: 'address', value: USER_ADDRESS },
+    ],
+    value: [0, 5000000], // outcome A, 5 XLM
+};
+
+const RAW_CLAIM_WINNINGS_EVENT = {
+    id: 'ledger-002',
+    txHash: '0xdef456',
+    ledgerClosedAt: '2024-01-16T12:00:00Z',
+    ledger: 200,
+    contractId: 'CTEST123CONTRACT',
+    topic: [
+        { type: 'symbol', value: 'claim_winnings' },
+        { type: 'u32', value: 5 },
+        { type: 'address', value: USER_ADDRESS },
+    ],
+    value: { type: 'i128', value: 9800000 },
+};
+
+const RAW_CREATE_POOL_EVENT = {
+    id: 'ledger-003',
+    txHash: '0xghi789',
+    ledgerClosedAt: '2024-01-14T08:00:00Z',
+    ledger: 50,
+    contractId: 'CTEST123CONTRACT',
+    topic: [
+        { type: 'symbol', value: 'create_pool' },
+        { type: 'u32', value: 5 },
+    ],
+    value: { type: 'address', value: USER_ADDRESS },
+};
+
+const RAW_SETTLE_POOL_EVENT = {
+    id: 'ledger-004',
+    txHash: '0xjkl012',
+    ledgerClosedAt: '2024-01-17T14:00:00Z',
+    ledger: 300,
+    contractId: 'CTEST123CONTRACT',
+    topic: [
+        { type: 'symbol', value: 'settle_pool' },
+        { type: 'u32', value: 5 },
+    ],
+    value: 1, // outcome B won
+};
+
+// ---------------------------------------------------------------------------
+// decodeSorobanEvent
+// ---------------------------------------------------------------------------
+
+describe('decodeSorobanEvent', () => {
+    it('decodes a place_bet event', () => {
+        const decoded = decodeSorobanEvent(RAW_PLACE_BET_EVENT);
+        expect(decoded).not.toBeNull();
+        expect(decoded!.name).toBe('place_bet');
+        expect(decoded!.poolId).toBe(5);
+        expect(decoded!.user).toBe(USER_ADDRESS);
+        expect(decoded!.outcome).toBe(0);
+        expect(decoded!.amount).toBe(5000000);
+        expect(decoded!.txHash).toBe('0xabc123');
+    });
+
+    it('decodes a claim_winnings event', () => {
+        const decoded = decodeSorobanEvent(RAW_CLAIM_WINNINGS_EVENT);
+        expect(decoded).not.toBeNull();
+        expect(decoded!.name).toBe('claim_winnings');
+        expect(decoded!.poolId).toBe(5);
+        expect(decoded!.user).toBe(USER_ADDRESS);
+        expect(decoded!.winnings).toBe(9800000);
+    });
+
+    it('decodes a create_pool event', () => {
+        const decoded = decodeSorobanEvent(RAW_CREATE_POOL_EVENT);
+        expect(decoded).not.toBeNull();
+        expect(decoded!.name).toBe('create_pool');
+        expect(decoded!.poolId).toBe(5);
+    });
+
+    it('decodes a settle_pool event', () => {
+        const decoded = decodeSorobanEvent(RAW_SETTLE_POOL_EVENT);
+        expect(decoded).not.toBeNull();
+        expect(decoded!.name).toBe('settle_pool');
+        expect(decoded!.poolId).toBe(5);
+        expect(decoded!.winningOutcome).toBe(1);
+    });
+
+    it('returns null for unknown event names', () => {
+        const raw = { ...RAW_PLACE_BET_EVENT, topic: [{ type: 'symbol', value: 'unknown_event' }] };
+        expect(decodeSorobanEvent(raw)).toBeNull();
+    });
+
+    it('returns null for empty topics', () => {
+        const raw = { ...RAW_PLACE_BET_EVENT, topic: [] };
+        expect(decodeSorobanEvent(raw)).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// mapEventToActivityItem
+// ---------------------------------------------------------------------------
+
+describe('mapEventToActivityItem', () => {
+    const EXPLORER = 'https://stellar.expert/explorer/testnet';
+
+    it('maps place_bet to bet-placed ActivityItem', () => {
+        const decoded = decodeSorobanEvent(RAW_PLACE_BET_EVENT)!;
+        const item = mapEventToActivityItem(decoded, EXPLORER);
+        expect(item).not.toBeNull();
+        expect(item!.type).toBe('bet-placed');
+        expect(item!.status).toBe('success');
+        expect(item!.poolId).toBe(5);
+        expect(item!.amount).toBe(5000000);
+        expect(item!.event?.type).toBe('bet');
+        expect(item!.event?.outcome).toBe(0);
+        expect(item!.explorerUrl).toBe(`${EXPLORER}/tx/0xabc123`);
+    });
+
+    it('maps claim_winnings to winnings-claimed ActivityItem', () => {
+        const decoded = decodeSorobanEvent(RAW_CLAIM_WINNINGS_EVENT)!;
+        const item = mapEventToActivityItem(decoded, EXPLORER);
+        expect(item).not.toBeNull();
+        expect(item!.type).toBe('winnings-claimed');
+        expect(item!.event?.type).toBe('claim');
+        expect(item!.event?.winnerAmount).toBe(9800000);
+    });
+
+    it('maps create_pool to pool-created ActivityItem', () => {
+        const decoded = decodeSorobanEvent(RAW_CREATE_POOL_EVENT)!;
+        const item = mapEventToActivityItem(decoded, EXPLORER);
+        expect(item).not.toBeNull();
+        expect(item!.type).toBe('pool-created');
+        expect(item!.event?.type).toBe('pool-creation');
+    });
+
+    it('maps settle_pool to contract-call ActivityItem', () => {
+        const decoded = decodeSorobanEvent(RAW_SETTLE_POOL_EVENT)!;
+        const item = mapEventToActivityItem(decoded, EXPLORER);
+        expect(item).not.toBeNull();
+        expect(item!.type).toBe('contract-call');
+        expect(item!.event?.type).toBe('settlement');
+        expect(item!.event?.outcome).toBe(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// getUserActivityFromSoroban
+// ---------------------------------------------------------------------------
+
+describe('getUserActivityFromSoroban', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('fetches and maps Soroban events into ActivityItems', async () => {
+        vi.mocked(fetch).mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                result: {
+                    events: [RAW_PLACE_BET_EVENT, RAW_CLAIM_WINNINGS_EVENT],
+                },
+            }),
+        } as any);
+
+        const items = await getUserActivityFromSoroban(USER_ADDRESS, 20, TEST_CONFIG);
+
+        expect(items).toHaveLength(2);
+        // Should be sorted newest first
+        expect(items[0].type).toBe('winnings-claimed');
+        expect(items[1].type).toBe('bet-placed');
+    });
+
+    it('filters out events not belonging to the user', async () => {
+        const otherUserEvent = {
+            ...RAW_PLACE_BET_EVENT,
+            topic: [
+                { type: 'symbol', value: 'place_bet' },
+                { type: 'u32', value: 5 },
+                { type: 'address', value: 'GBOTHER_USER_ADDRESS' },
+            ],
+        };
+
+        vi.mocked(fetch).mockResolvedValue({
+            ok: true,
+            json: async () => ({ result: { events: [otherUserEvent] } }),
+        } as any);
+
+        const items = await getUserActivityFromSoroban(USER_ADDRESS, 20, TEST_CONFIG);
+        expect(items).toHaveLength(0);
+    });
+
+    it('returns empty array on RPC error', async () => {
+        vi.mocked(fetch).mockResolvedValue({ ok: false, status: 500 } as any);
+        const items = await getUserActivityFromSoroban(USER_ADDRESS, 20, TEST_CONFIG);
+        expect(items).toEqual([]);
+    });
+
+    it('returns empty array when config is missing contractId', async () => {
+        const items = await getUserActivityFromSoroban(USER_ADDRESS, 20, {
+            ...TEST_CONFIG,
+            contractId: '',
+        });
+        expect(fetch).not.toHaveBeenCalled();
+        expect(items).toEqual([]);
+    });
+
+    it('returns empty array when RPC returns an error object', async () => {
+        vi.mocked(fetch).mockResolvedValue({
+            ok: true,
+            json: async () => ({ error: { message: 'startLedger must be positive' } }),
+        } as any);
+
+        const items = await getUserActivityFromSoroban(USER_ADDRESS, 20, TEST_CONFIG);
+        expect(items).toEqual([]);
+    });
+});


### PR DESCRIPTION
## feat: Soroban event service for activity feed

### Problem

The activity feed was built on Stacks API assumptions — fetching
`/extended/v1/address/:addr/transactions` from Hiro and parsing
Stacks-specific transaction shapes. The underlying contract is a
Soroban contract on Stellar, so the pipeline was fundamentally
mismatched.

### What changed

**New: `web/app/lib/soroban-event-service.ts`**

Canonical event service for the activity feed. Three exported functions:

- `decodeSorobanEvent` — normalises raw Soroban RPC topic/value payloads
  (handles `{ type, value }` objects, plain primitives, and arrays) into
  typed `DecodedSorobanEvent` objects
- `mapEventToActivityItem` — converts a decoded event into an `ActivityItem`
  for the UI; covers `place_bet → bet-placed`, `claim_winnings → winnings-claimed`,
  `create_pool → pool-created`, `settle_pool → contract-call`
- `getUserActivityFromSoroban` — calls the Soroban RPC `getEvents` method,
  filters results to the requesting user, sorts newest-first, and returns
  `ActivityItem[]`

Event schema follows `web/docs/CONTRACT_EVENTS.md` exactly.

**Runtime config**

- Added `SorobanConfig` type (`rpcUrl`, `explorerUrl`, `contractId`) to
  `RuntimeConfig`
- `getRuntimeConfig()` now populates `soroban` from `WALLETCONNECT_CONFIG.soroban`
  and the new `NEXT_PUBLIC_SOROBAN_CONTRACT_ID` env var
- Added `WALLETCONNECT_CONFIG.soroban` with testnet
  (`https://soroban-testnet.stellar.org`) and mainnet endpoints

**Adapter layer**

- `predinexReadApi` gains `getUserActivitySoroban` — thin wrapper that
  resolves config and delegates to the event service
- Old `getUserActivity` (Stacks) kept and marked `@deprecated` for
  backwards compat
- `adapters/index.ts` re-exports the new service types and functions

**Hook**

- `useUserActivity` now calls `predinexReadApi.getUserActivitySoroban`
  instead of the Stacks path

closes #216 