### PR TITLE
feat(contract): void-and-refund flow for unresolved markets

### DIFF
--- a/contracts/predinex/src/lib.rs
+++ b/contracts/predinex/src/lib.rs
@@ -13,23 +13,31 @@ pub enum DataKey {
     Treasury,
     TreasuryRecipient,
     DelegatedSettler(u32),
+    FreezeAdmin,
 }
 
 /// Explicit lifecycle status for a prediction pool.
 ///
 /// Transitions:
 ///   Open  ──(expiry reached + settle_pool called)──►  Settled(winning_outcome)
+///   Open  ──(void_pool called by creator)──────────►  Voided
 ///
-/// Future terminal states (Cancelled, Voided, Paused) can be added here
-/// without ambiguity, because status is the single source of truth.
-#[derive(Clone, PartialEq)]
+/// Terminal states are mutually exclusive; status is the single source of truth.
+#[derive(Clone, PartialEq, Debug)]
 #[contracttype]
 pub enum PoolStatus {
     /// Accepting bets; expiry has not yet passed.
     Open,
+    /// Alias for Open — kept for backward compatibility with older storage entries.
+    Active,
     /// Betting closed and a winning outcome has been declared.
-    /// The inner value is the winning outcome index (0 or 1).
     Settled(u32),
+    /// Pool was declared unresolvable; users may claim full refunds via `claim_refund`.
+    Voided,
+    /// Pool is frozen by the freeze admin; bets and claims are blocked pending review.
+    Frozen,
+    /// Pool settlement is under dispute; claims are blocked pending resolution.
+    Disputed,
 }
 
 #[derive(Clone)]
@@ -166,7 +174,7 @@ impl PredinexContract {
             winning_outcome: None,
             created_at,
             expiry,
-            status: PoolStatus::Active,
+            status: PoolStatus::Open,
         };
 
         env.storage()
@@ -197,10 +205,6 @@ impl PredinexContract {
 
         if pool.status != PoolStatus::Open {
             panic!("Pool already settled");
-        }
-
-        if pool.status != PoolStatus::Active {
-            panic!("Pool is not active");
         }
 
         if env.ledger().timestamp() >= pool.expiry {
@@ -347,6 +351,84 @@ impl PredinexContract {
         );
     }
 
+    /// Mark a pool as void. Only the creator may call this before the pool is
+    /// settled or already voided. Once voided, users call `claim_refund` to
+    /// recover their original stakes in full.
+    pub fn void_pool(env: Env, caller: Address, pool_id: u32) {
+        caller.require_auth();
+
+        let mut pool = env
+            .storage()
+            .persistent()
+            .get::<_, Pool>(&DataKey::Pool(pool_id))
+            .expect("Pool not found");
+
+        if caller != pool.creator {
+            panic!("Unauthorized");
+        }
+
+        match pool.status {
+            PoolStatus::Open => {}
+            PoolStatus::Voided => panic!("Already voided"),
+            _ => panic!("Pool already settled"),
+        }
+
+        pool.status = PoolStatus::Voided;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Pool(pool_id), &pool);
+
+        env.events()
+            .publish((Symbol::new(&env, "void_pool"), pool_id), caller);
+    }
+
+    /// Refund a user's original stake from a voided pool. No fee is taken.
+    /// The bet entry is removed after the refund to prevent double-claims.
+    pub fn claim_refund(env: Env, user: Address, pool_id: u32) -> i128 {
+        user.require_auth();
+
+        let pool = env
+            .storage()
+            .persistent()
+            .get::<_, Pool>(&DataKey::Pool(pool_id))
+            .expect("Pool not found");
+
+        if pool.status != PoolStatus::Voided {
+            panic!("Pool not voided");
+        }
+
+        let user_bet = env
+            .storage()
+            .persistent()
+            .get::<_, UserBet>(&DataKey::UserBet(pool_id, user.clone()))
+            .expect("No bet found");
+
+        let refund = user_bet.total_bet;
+        if refund == 0 {
+            panic!("Nothing to refund");
+        }
+
+        let token_address = env
+            .storage()
+            .persistent()
+            .get::<_, Address>(&DataKey::Token)
+            .expect("Not initialized");
+        let token_client = token::Client::new(&env, &token_address);
+
+        token_client.transfer(&env.current_contract_address(), &user, &refund);
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::UserBet(pool_id, user.clone()));
+
+        env.events().publish(
+            (Symbol::new(&env, "claim_refund"), pool_id, user),
+            refund,
+        );
+
+        refund
+    }
+
     pub fn claim_winnings(env: Env, user: Address, pool_id: u32) -> i128 {
         user.require_auth();
 
@@ -358,12 +440,10 @@ impl PredinexContract {
 
         let winning_outcome = match pool.status {
             PoolStatus::Settled(outcome) => outcome,
+            PoolStatus::Voided => panic!("Pool is voided; use claim_refund"),
+            PoolStatus::Frozen | PoolStatus::Disputed => panic!("Pool is frozen or disputed; claims are blocked"),
             _ => panic!("Pool not settled"),
         };
-
-        if pool.status != PoolStatus::Active {
-            panic!("Pool is frozen or disputed; claims are blocked");
-        }
 
         let user_bet = env
             .storage()
@@ -553,7 +633,7 @@ impl PredinexContract {
             .get::<_, Pool>(&DataKey::Pool(pool_id))
             .expect("Pool not found");
 
-        if !pool.settled {
+        if !matches!(pool.status, PoolStatus::Settled(_)) {
             panic!("Pool must be settled before it can be disputed");
         }
 
@@ -585,11 +665,11 @@ impl PredinexContract {
             .get::<_, Pool>(&DataKey::Pool(pool_id))
             .expect("Pool not found");
 
-        if pool.status == PoolStatus::Active {
+        if pool.status != PoolStatus::Frozen && pool.status != PoolStatus::Disputed {
             panic!("Pool is not frozen or disputed");
         }
 
-        pool.status = PoolStatus::Active;
+        pool.status = PoolStatus::Open;
         env.storage()
             .persistent()
             .set(&DataKey::Pool(pool_id), &pool);

--- a/contracts/predinex/src/test.rs
+++ b/contracts/predinex/src/test.rs
@@ -1185,8 +1185,7 @@ fn f1_delegated_settler_can_settle_after_expiry() {
     t.client.settle_pool(&settler, &pool_id, &0u32);
 
     let pool = t.client.get_pool(&pool_id).expect("pool must exist");
-    assert!(pool.settled, "pool must be settled");
-    assert_eq!(pool.winning_outcome, Some(0u32));
+    assert_eq!(pool.status, PoolStatus::Settled(0), "pool must be settled");
 }
 
 /// F2: Unauthorized address cannot settle even after expiry.
@@ -1229,8 +1228,7 @@ fn f4_creator_can_settle_without_delegated_settler() {
     t.client.settle_pool(&t.admin, &pool_id, &1u32);
 
     let pool = t.client.get_pool(&pool_id).expect("pool must exist");
-    assert!(pool.settled);
-    assert_eq!(pool.winning_outcome, Some(1u32));
+    assert_eq!(pool.status, PoolStatus::Settled(1));
 }
 
 /// F5: get_delegated_settler returns the assigned settler.
@@ -1254,4 +1252,46 @@ fn f6_get_delegated_settler_returns_none_when_unset() {
 
     let stored = t.client.get_delegated_settler(&pool_id);
     assert!(stored.is_none());
+}
+
+// ── Issue #161: void-and-refund flow ─────────────────────────────────────────
+
+/// Void a pool with users on both sides; each user reclaims their exact stake.
+#[test]
+fn void_and_refund_returns_original_stakes() {
+    let t = setup();
+    let pool_id = make_pool(&t);
+
+    let user1 = Address::generate(&t.env);
+    let user2 = Address::generate(&t.env);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&t.env, &t.token);
+    token_admin.mint(&user1, &500);
+    token_admin.mint(&user2, &300);
+
+    t.client.place_bet(&user1, &pool_id, &0, &500);
+    t.client.place_bet(&user2, &pool_id, &1, &300);
+
+    t.client.void_pool(&t.admin, &pool_id);
+
+    let pool = t.client.get_pool(&pool_id).unwrap();
+    assert_eq!(pool.status, super::PoolStatus::Voided);
+
+    let token = soroban_sdk::token::Client::new(&t.env, &t.token);
+    assert_eq!(t.client.claim_refund(&user1, &pool_id), 500);
+    assert_eq!(token.balance(&user1), 500);
+
+    assert_eq!(t.client.claim_refund(&user2, &pool_id), 300);
+    assert_eq!(token.balance(&user2), 300);
+}
+
+/// claim_winnings on a voided pool must be rejected.
+#[test]
+#[should_panic(expected = "Pool is voided; use claim_refund")]
+fn claim_winnings_rejected_on_voided_pool() {
+    let t = setup();
+    let pool_id = make_pool(&t);
+
+    t.client.place_bet(&t.user, &pool_id, &0, &200);
+    t.client.void_pool(&t.admin, &pool_id);
+    t.client.claim_winnings(&t.user, &pool_id);
 }


### PR DESCRIPTION
## Summary

Implements the void-and-refund flow for unresolved markets as described in #161.

## Changes

- **`void_pool`** — creator-only entry point that transitions a pool from `Open` → `Voided`
- **`claim_refund`** — lets any bettor reclaim their exact original stake from a voided pool; bet entry is removed after to prevent double-claims
- **`claim_winnings`** — explicitly rejects voided pools with `Pool is voided; use claim_refund`
- Added `Voided`, `Frozen`, `Disputed`, `Active` variants to `PoolStatus` and `FreezeAdmin` to `DataKey` (required for compilation)
- Fixed several pre-existing stale references that prevented the contract from compiling

## Tests

Two new tests covering the acceptance criteria:

- `void_and_refund_returns_original_stakes` — voids a pool with bettors on both sides and verifies each user reclaims their exact stake
- `claim_winnings_rejected_on_voided_pool` — asserts `claim_winnings` panics with the correct message on a voided pool

All 45 tests pass.

Closes #161