### PR TITLE
feat(#248): add frontend error reporting with wallet/tx redaction

### DIFF
--- a/web/app/components/WalletErrorBoundary.tsx
+++ b/web/app/components/WalletErrorBoundary.tsx
@@ -49,6 +49,13 @@ export class WalletErrorBoundary extends Component<Props, State> {
       this.props.onError(error, errorInfo);
     }
 
+    import('@/app/lib/error-reporter').then(({ reportError }) =>
+      reportError(error, {
+        componentStack: errorInfo.componentStack ?? undefined,
+        boundary: 'WalletErrorBoundary',
+      })
+    );
+
     // Log to external service in production
     if (process.env.NODE_ENV === 'production') {
       this.logErrorToService(error, errorInfo);

--- a/web/app/lib/error-reporter.ts
+++ b/web/app/lib/error-reporter.ts
@@ -1,0 +1,108 @@
+/**
+ * Error Reporter
+ *
+ * Configurable hook for structured runtime error reporting.
+ * Wallet addresses, signatures, and sensitive transaction fields are
+ * redacted before any payload leaves the browser.
+ *
+ * ## Setup
+ * Call `configureErrorReporter` once at app startup (e.g. in layout.tsx):
+ *
+ *   configureErrorReporter({
+ *     onReport: (event) => myAnalytics.captureException(event),
+ *   });
+ *
+ * If no handler is configured the reporter is a no-op, making the
+ * integration fully optional.
+ */
+
+export interface ErrorEvent {
+  message: string;
+  /** Sanitised stack trace — wallet/tx data stripped */
+  stack?: string;
+  /** React component stack when thrown inside an error boundary */
+  componentStack?: string;
+  /** Logical area that caught the error, e.g. "WalletErrorBoundary" */
+  boundary?: string;
+  timestamp: string;
+}
+
+export interface ErrorReporterConfig {
+  /** Called with the sanitised event. Wire up your analytics provider here. */
+  onReport: (event: ErrorEvent) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+/**
+ * Patterns that identify sensitive data that must never appear in reports.
+ *
+ * - Stellar/Stacks public keys and addresses (G…, C…, S…, SP…, ST…)
+ * - Generic hex strings ≥ 32 chars (covers signatures, hashes, private keys)
+ * - XDR blobs (base64 ≥ 64 chars)
+ */
+const REDACT_PATTERNS: Array<[RegExp, string]> = [
+  // Stellar public keys (G...) and contract IDs (C...) — 55–56 char base32 strkeys
+  [/(?<![A-Z2-7])[GC][A-Z2-7]{54,55}(?![A-Z2-7])/g, '[STELLAR_ADDRESS]'],
+  // Stellar secret keys (S...) — 55–56 char base32 strkeys
+  [/(?<![A-Z2-7])S[A-Z2-7]{54,55}(?![A-Z2-7])/g, '[REDACTED]'],
+  // Stacks addresses (SP... / ST...)
+  [/\bS[PT][0-9A-Z]{30,}\b/g, '[STACKS_ADDRESS]'],
+  // Long base64 strings containing +, / or = — XDR envelopes (run before hex)
+  [/[A-Za-z0-9+/]{32,}={1,2}|[A-Za-z0-9+/]*[+/][A-Za-z0-9+/]{31,}/g, '[BASE64_REDACTED]'],
+  // Long pure-hex strings — signatures, hashes, private keys
+  [/\b[0-9a-fA-F]{32,}\b/g, '[HEX_REDACTED]'],
+];
+
+export function redactSensitiveData(text: string): string {
+  let result = text;
+  for (const [pattern, replacement] of REDACT_PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Reporter
+// ---------------------------------------------------------------------------
+
+let _config: ErrorReporterConfig | null = null;
+
+/** Call once at app startup to enable reporting. */
+export function configureErrorReporter(config: ErrorReporterConfig): void {
+  _config = config;
+}
+
+/**
+ * Report a runtime error.
+ * Safe to call unconditionally — silently no-ops when no handler is configured.
+ */
+export function reportError(
+  error: Error,
+  options: { componentStack?: string; boundary?: string } = {}
+): void {
+  if (!_config) return;
+
+  const event: ErrorEvent = {
+    message: redactSensitiveData(error.message),
+    stack: error.stack ? redactSensitiveData(error.stack) : undefined,
+    componentStack: options.componentStack
+      ? redactSensitiveData(options.componentStack)
+      : undefined,
+    boundary: options.boundary,
+    timestamp: new Date().toISOString(),
+  };
+
+  try {
+    _config.onReport(event);
+  } catch {
+    // Never let the reporter itself crash the app
+  }
+}
+
+/** Reset config — intended for tests only. */
+export function __resetErrorReporterForTests(): void {
+  _config = null;
+}

--- a/web/components/ErrorBoundary.tsx
+++ b/web/components/ErrorBoundary.tsx
@@ -23,6 +23,12 @@ class ErrorBoundary extends Component<Props, State> {
 
     public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
         console.error('Uncaught error:', error, errorInfo);
+        import('@/app/lib/error-reporter').then(({ reportError }) =>
+            reportError(error, {
+                componentStack: errorInfo.componentStack ?? undefined,
+                boundary: 'ErrorBoundary',
+            })
+        );
     }
 
     private handleReset = () => {

--- a/web/components/RouteErrorBoundary.tsx
+++ b/web/components/RouteErrorBoundary.tsx
@@ -75,6 +75,12 @@ export class RouteErrorBoundary extends Component<
       error,
       errorInfo
     );
+    import('@/app/lib/error-reporter').then(({ reportError }) =>
+      reportError(error, {
+        componentStack: errorInfo.componentStack ?? undefined,
+        boundary: `RouteErrorBoundary(${this.props.routeName ?? 'unknown'})`,
+      })
+    );
   }
 
   private handleReset = () => {

--- a/web/tests/lib/error-reporter.test.ts
+++ b/web/tests/lib/error-reporter.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  configureErrorReporter,
+  reportError,
+  redactSensitiveData,
+  __resetErrorReporterForTests,
+  type ErrorEvent,
+} from '@/app/lib/error-reporter';
+
+beforeEach(() => {
+  __resetErrorReporterForTests();
+});
+
+// ---------------------------------------------------------------------------
+// Redaction unit tests
+// ---------------------------------------------------------------------------
+
+describe('redactSensitiveData', () => {
+  it('redacts Stellar public keys (G...)', () => {
+    // Valid 56-char Stellar public key (base32 uppercase)
+    const address = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+    expect(redactSensitiveData(`addr=${address}`)).toBe('addr=[STELLAR_ADDRESS]');
+  });
+
+  it('redacts Stellar contract IDs (C...)', () => {
+    const contract = 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA';
+    expect(redactSensitiveData(contract)).toBe('[STELLAR_ADDRESS]');
+  });
+
+  it('redacts Stellar secret keys (S...)', () => {
+    // Valid 56-char Stellar secret key (base32 uppercase, starts with S)
+    const secret = 'SCZANGBA5RLCN6MFNKDKXNQXBDGXKM5JXQXQXQXQXQXQXQXQXQXQXQX';
+    expect(redactSensitiveData(secret)).toBe('[REDACTED]');
+  });
+
+  it('redacts Stacks addresses (SP... / ST...)', () => {
+    expect(redactSensitiveData('SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7')).toBe(
+      '[STACKS_ADDRESS]'
+    );
+    expect(redactSensitiveData('ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7')).toBe(
+      '[STACKS_ADDRESS]'
+    );
+  });
+
+  it('redacts long hex strings (signatures / hashes)', () => {
+    const sig = 'a'.repeat(64);
+    expect(redactSensitiveData(`sig=${sig}`)).toBe('sig=[HEX_REDACTED]');
+  });
+
+  it('redacts long base64 strings (XDR envelopes)', () => {
+    // Contains '/' so it's unambiguously base64, not hex
+    const xdr = 'AAAA'.repeat(8) + '/AAA' + 'AAAA'.repeat(8);
+    expect(redactSensitiveData(xdr)).toBe('[BASE64_REDACTED]');
+  });
+
+  it('leaves short, non-sensitive strings unchanged', () => {
+    expect(redactSensitiveData('Network timeout after 5000ms')).toBe(
+      'Network timeout after 5000ms'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reporter hook tests
+// ---------------------------------------------------------------------------
+
+describe('reportError', () => {
+  it('is a no-op when no handler is configured', () => {
+    // Should not throw
+    expect(() => reportError(new Error('boom'))).not.toThrow();
+  });
+
+  it('calls the configured handler with a sanitised payload', () => {
+    const received: ErrorEvent[] = [];
+    configureErrorReporter({ onReport: (e) => received.push(e) });
+
+    reportError(new Error('Something failed'));
+
+    expect(received).toHaveLength(1);
+    expect(received[0].message).toBe('Something failed');
+    expect(received[0].boundary).toBeUndefined();
+    expect(received[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('redacts wallet address embedded in the error message', () => {
+    const received: ErrorEvent[] = [];
+    configureErrorReporter({ onReport: (e) => received.push(e) });
+
+    const walletAddr = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+    reportError(new Error(`Failed for address ${walletAddr}`));
+
+    expect(received[0].message).not.toContain(walletAddr);
+    expect(received[0].message).toContain('[STELLAR_ADDRESS]');
+  });
+
+  it('redacts wallet address in the component stack', () => {
+    const received: ErrorEvent[] = [];
+    configureErrorReporter({ onReport: (e) => received.push(e) });
+
+    const walletAddr = 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7';
+    reportError(new Error('tx error'), {
+      componentStack: `\n  at WalletButton (addr=${walletAddr})`,
+      boundary: 'WalletErrorBoundary',
+    });
+
+    expect(received[0].componentStack).not.toContain(walletAddr);
+    expect(received[0].boundary).toBe('WalletErrorBoundary');
+  });
+
+  it('does not propagate exceptions thrown by the handler', () => {
+    configureErrorReporter({
+      onReport: () => {
+        throw new Error('reporter exploded');
+      },
+    });
+    expect(() => reportError(new Error('original'))).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #248

---

- Add error-reporter.ts: configureErrorReporter hook + redactSensitiveData
- Redacts Stellar/Stacks addresses, secret keys, hex signatures, XDR blobs
- Wire reportError into ErrorBoundary, RouteErrorBoundary, WalletErrorBoundary
- Integration is opt-in (no-op until configureErrorReporter is called)
- 12 tests covering redaction correctness and hook behaviour