### PR TITLE
feat(contract): add preview_claimable_amount read method (#159)

### DIFF
--- a/contracts/predinex/src/lib.rs
+++ b/contracts/predinex/src/lib.rs
@@ -130,6 +130,29 @@ pub struct UserPoolPosition {
     pub total_bet: i128,
 }
 
+/// #159 — Result type returned by `preview_claimable_amount`.
+///
+/// Variants
+/// --------
+/// - `Unclaimable`  – pool is not yet settled (or is frozen/disputed/cancelled);
+///                    no payout is available regardless of the user's position.
+/// - `NeverBet`     – pool is settled but the user has no position (or already claimed).
+/// - `NotEligible`  – pool is settled; user bet on the losing side.
+/// - `Claimable(i128)` – pool is settled; user bet on the winning side and the
+///                    value equals exactly what `claim_winnings` would transfer.
+#[derive(Clone, PartialEq, Debug)]
+#[contracttype]
+pub enum ClaimPreview {
+    /// Pool is not in a settled state; payout cannot be computed yet.
+    Unclaimable,
+    /// User has no active position in this pool (never bet or already claimed).
+    NeverBet,
+    /// User bet on the losing side; no payout available.
+    NotEligible,
+    /// User bet on the winning side; value is the exact transferable amount.
+    Claimable(i128),
+}
+
 /// Event payload emitted by `place_bet`.
 ///
 /// Fields
@@ -1099,6 +1122,70 @@ impl PredinexContract {
                 None => ClaimStatus::NeverBet,
             },
         }
+    }
+
+    /// #159 — Read-only payout preview for a user in a given pool.
+    ///
+    /// Returns a `ClaimPreview` that the frontend can use to display the
+    /// claimable amount or explain why nothing is claimable, without
+    /// reimplementing payout logic off-chain.
+    ///
+    /// The `Claimable(amount)` value is computed with the same formula used by
+    /// `claim_winnings`, so the preview is always exact for settled pools.
+    ///
+    /// | Pool status          | Bet record          | Result              |
+    /// |----------------------|---------------------|---------------------|
+    /// | Open / Frozen /      | any                 | Unclaimable         |
+    /// | Disputed / Cancelled |                     |                     |
+    /// | Voided               | any                 | Unclaimable         |
+    /// | Settled(w)           | absent / claimed    | NeverBet            |
+    /// | Settled(w)           | losing side only    | NotEligible         |
+    /// | Settled(w)           | winning side > 0    | Claimable(amount)   |
+    pub fn preview_claimable_amount(env: Env, pool_id: u32, user: Address) -> ClaimPreview {
+        let pool = match env
+            .storage()
+            .persistent()
+            .get::<_, Pool>(&DataKey::Pool(pool_id))
+        {
+            Some(p) => p,
+            None => return ClaimPreview::Unclaimable,
+        };
+
+        let winning_outcome = match pool.status {
+            PoolStatus::Settled(outcome) => outcome,
+            _ => return ClaimPreview::Unclaimable,
+        };
+
+        let bet: UserBet = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::UserBet(pool_id, user))
+        {
+            Some(b) => b,
+            None => return ClaimPreview::NeverBet,
+        };
+
+        let user_winning_bet = if winning_outcome == 0 {
+            bet.amount_a
+        } else {
+            bet.amount_b
+        };
+
+        if user_winning_bet == 0 {
+            return ClaimPreview::NotEligible;
+        }
+
+        let pool_winning_total = if winning_outcome == 0 {
+            pool.total_a
+        } else {
+            pool.total_b
+        };
+        let total_pool_balance = pool.total_a + pool.total_b;
+        let fee = (total_pool_balance * 2) / 100;
+        let net_pool_balance = total_pool_balance - fee;
+        let amount = (user_winning_bet * net_pool_balance) / pool_winning_total;
+
+        ClaimPreview::Claimable(amount)
     }
 
     pub fn get_participant_count(env: Env, pool_id: u32) -> u32 {

--- a/contracts/predinex/src/test.rs
+++ b/contracts/predinex/src/test.rs
@@ -2553,3 +2553,136 @@ fn l4_successful_claim_reconciles_treasury_and_balances() {
         "remaining contract balance must equal the unclaimed treasury fee"
     );
 }
+
+// ── #159 preview_claimable_amount ────────────────────────────────────────────
+
+/// Helper: set up a contract + token, create a pool, and return all handles.
+fn setup_preview_env(
+    env: &Env,
+) -> (
+    PredinexContractClient<'_>,
+    token::Client<'_>,
+    token::StellarAssetClient<'_>,
+    Address, // contract_id
+    Address, // creator
+    Address, // user_a (bets on A)
+    Address, // user_b (bets on B)
+    u32,     // pool_id
+) {
+    let contract_id = env.register(PredinexContract, ());
+    let client = PredinexContractClient::new(env, &contract_id);
+
+    let token_admin = Address::generate(env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token = token::Client::new(env, &token_id.address());
+    let token_admin_client = token::StellarAssetClient::new(env, &token_id.address());
+
+    client.initialize(&token_id.address(), &token_admin);
+
+    let creator = Address::generate(env);
+    let user_a = Address::generate(env);
+    let user_b = Address::generate(env);
+
+    token_admin_client.mint(&user_a, &1000);
+    token_admin_client.mint(&user_b, &1000);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(env, "Preview Test"),
+        &String::from_str(env, ""),
+        &String::from_str(env, "Yes"),
+        &String::from_str(env, "No"),
+        &3600u64,
+    );
+
+    (
+        client,
+        token,
+        token_admin_client,
+        contract_id,
+        creator,
+        user_a,
+        user_b,
+        pool_id,
+    )
+}
+
+/// AC: Call the preview method before settlement and verify the response
+/// reflects the unclaimable state.
+#[test]
+fn test_preview_claimable_amount_before_settlement() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _token, _token_admin, _contract_id, _creator, user_a, user_b, pool_id) =
+        setup_preview_env(&env);
+
+    // user_a bets on A, user_b bets on B — pool is still Open
+    client.place_bet(&user_a, &pool_id, &0, &300);
+    client.place_bet(&user_b, &pool_id, &1, &200);
+
+    // Both users should see Unclaimable while the pool is open
+    assert_eq!(
+        client.preview_claimable_amount(&pool_id, &user_a),
+        ClaimPreview::Unclaimable,
+        "winner-side bettor must see Unclaimable before settlement"
+    );
+    assert_eq!(
+        client.preview_claimable_amount(&pool_id, &user_b),
+        ClaimPreview::Unclaimable,
+        "loser-side bettor must see Unclaimable before settlement"
+    );
+
+    // A user with no position also sees Unclaimable (pool not settled)
+    let outsider = Address::generate(&env);
+    assert_eq!(
+        client.preview_claimable_amount(&pool_id, &outsider),
+        ClaimPreview::Unclaimable,
+        "non-participant must see Unclaimable before settlement"
+    );
+}
+
+/// AC: Call the preview method after settlement and verify it matches the
+/// amount returned by claim_winnings.
+#[test]
+fn test_preview_claimable_amount_after_settlement_matches_claim() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _token, _token_admin, _contract_id, creator, user_a, user_b, pool_id) =
+        setup_preview_env(&env);
+
+    client.place_bet(&user_a, &pool_id, &0, &300); // bets on A
+    client.place_bet(&user_b, &pool_id, &1, &200); // bets on B
+
+    // Advance time past expiry and settle — outcome A wins
+    env.ledger().with_mut(|l| l.timestamp = 3601);
+    client.settle_pool(&creator, &pool_id, &0);
+
+    // user_a (winner): preview must equal what claim_winnings returns
+    let preview_winner = client.preview_claimable_amount(&pool_id, &user_a);
+    let expected_amount = match preview_winner.clone() {
+        ClaimPreview::Claimable(v) => v,
+        other => panic!("expected Claimable, got {:?}", other),
+    };
+    let actual_winnings = client.claim_winnings(&user_a, &pool_id);
+    assert_eq!(
+        expected_amount, actual_winnings,
+        "preview must match claim_winnings exactly"
+    );
+
+    // user_b (loser): NotEligible
+    assert_eq!(
+        client.preview_claimable_amount(&pool_id, &user_b),
+        ClaimPreview::NotEligible,
+        "loser must see NotEligible after settlement"
+    );
+
+    // outsider (no position): NeverBet
+    let outsider = Address::generate(&env);
+    assert_eq!(
+        client.preview_claimable_amount(&pool_id, &outsider),
+        ClaimPreview::NeverBet,
+        "non-participant must see NeverBet after settlement"
+    );
+}


### PR DESCRIPTION
Adds a read-only ClaimPreview method so the frontend can display exact payout amounts and explain zero-claim states without reimplementing payout logic off-chain.

Changes
-------
- New ClaimPreview enum (Unclaimable | NeverBet | NotEligible | Claimable(i128))
- New preview_claimable_amount(pool_id, user) -> ClaimPreview method
  - Returns Unclaimable for any non-Settled pool status
  - Returns NeverBet when no bet record exists on a settled pool
  - Returns NotEligible when the user bet only on the losing side
  - Returns Claimable(amount) using the identical formula as claim_winnings
- Two acceptance-criteria tests:
  - test_preview_claimable_amount_before_settlement: verifies Unclaimable for all users while the pool is still Open
  - test_preview_claimable_amount_after_settlement_matches_claim: verifies Claimable amount equals claim_winnings return value, NotEligible for losers, and NeverBet for non-participants

Closes #159 