### PR TITLE
fix(wallet): remove Stacks chain ids from AppKit provider config (#210)

### DIFF
--- a/web/app/components/NetworkSwitcher.tsx
+++ b/web/app/components/NetworkSwitcher.tsx
@@ -2,10 +2,10 @@
 
 import { useAppKitNetwork } from '@reown/appkit/react';
 import { useWallet } from './WalletAdapterProvider';
-import { Globe, Check, AlertCircle } from 'lucide-react';
+import { Globe, AlertCircle } from 'lucide-react';
 import { useState } from 'react';
 import { NetworkType } from '@/app/lib/wallet-service';
-import { stacksNetworks } from '@/lib/appkit-config';
+import { stellarNetworks } from '@/lib/appkit-config';
 
 export function NetworkSwitcher() {
   const { switchNetwork, caipNetwork } = useAppKitNetwork();
@@ -26,11 +26,8 @@ export function NetworkSwitcher() {
     setError(null);
 
     try {
-      const targetNetwork = network === 'mainnet' ? stacksNetworks.mainnet : stacksNetworks.testnet;
-      // @ts-expect-error – stacksNetworks returns a Stacks-specific CaipNetwork shape that
-      // is structurally compatible with AppKit's switchNetwork parameter but not
-      // assignable to its declared CaipNetwork union type.
-      await switchNetwork(targetNetwork);
+      const targetNetwork = network === 'mainnet' ? stellarNetworks.mainnet : stellarNetworks.testnet;
+      await (switchNetwork as unknown as (n: typeof targetNetwork) => Promise<void>)(targetNetwork);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Network switch failed';
       setError(message);

--- a/web/lib/appkit-config.ts
+++ b/web/lib/appkit-config.ts
@@ -1,55 +1,94 @@
 /**
  * Reown AppKit Configuration
- * Network and wallet connection settings
+ *
+ * Defines the Stellar network metadata used to initialise AppKit and the
+ * supporting wallet UI (network switcher, mismatch warning).
+ *
+ * Supported networks
+ * ------------------
+ * - Stellar Public Network ("mainnet"), CAIP-2 id `stellar:pubnet`
+ * - Stellar Test Network ("testnet"),  CAIP-2 id `stellar:testnet`
+ *
+ * AppKit does not currently ship a first-party Stellar adapter, so these
+ * objects are plain CAIP-network descriptors. They are intentionally free of
+ * any Stacks chain ids — Predinex is a Stellar/Soroban app, and routing the
+ * provider through `stacks:*` ids would put the wallet UI on the wrong network
+ * (see issue #210).
  */
 
-import { STACKS_MAINNET, STACKS_TESTNET } from '@stacks/network';
+export type StellarNetworkKey = 'mainnet' | 'testnet';
 
-const stacksMainnet = STACKS_MAINNET;
-const stacksTestnet = STACKS_TESTNET;
+export interface StellarCaipNetwork {
+  id: `stellar:${string}`;
+  chainNamespace: 'stellar';
+  caipNetworkId: `stellar:${string}`;
+  name: string;
+  nativeCurrency: {
+    name: string;
+    symbol: string;
+    decimals: number;
+  };
+  rpcUrls: {
+    default: { http: readonly string[] };
+    public: { http: readonly string[] };
+  };
+  blockExplorers: {
+    default: { name: string; url: string };
+  };
+}
 
-export const WALLETCONNECT_PROJECT_ID = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || 'cbb72cc85764d1cd3b664790089a8fab';
+export const WALLETCONNECT_PROJECT_ID =
+  process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || 'cbb72cc85764d1cd3b664790089a8fab';
 
-export const stacksNetworks = {
+export const stellarNetworks: Record<StellarNetworkKey, StellarCaipNetwork> = {
   mainnet: {
-    id: 'stacks:mainnet',
-    name: 'Stacks Mainnet',
-    network: stacksMainnet,
+    id: 'stellar:pubnet',
+    chainNamespace: 'stellar',
+    caipNetworkId: 'stellar:pubnet',
+    name: 'Stellar Mainnet',
     nativeCurrency: {
-      name: 'Stacks',
-      symbol: 'STX',
-      decimals: 6,
+      name: 'Stellar Lumens',
+      symbol: 'XLM',
+      decimals: 7,
     },
     rpcUrls: {
-      default: { http: ['https://api.mainnet.hiro.so'] },
-      public: { http: ['https://api.mainnet.hiro.so'] },
+      default: { http: ['https://mainnet.stellar.validationcloud.io/v1/soroban/rpc'] },
+      public: { http: ['https://mainnet.stellar.validationcloud.io/v1/soroban/rpc'] },
     },
     blockExplorers: {
-      default: { name: 'Stacks Explorer', url: 'https://explorer.hiro.so' },
+      default: { name: 'Stellar Expert', url: 'https://stellar.expert/explorer/public' },
     },
   },
   testnet: {
-    id: 'stacks:testnet',
-    name: 'Stacks Testnet',
-    network: stacksTestnet,
+    id: 'stellar:testnet',
+    chainNamespace: 'stellar',
+    caipNetworkId: 'stellar:testnet',
+    name: 'Stellar Testnet',
     nativeCurrency: {
-      name: 'Stacks',
-      symbol: 'STX',
-      decimals: 6,
+      name: 'Stellar Lumens',
+      symbol: 'XLM',
+      decimals: 7,
     },
     rpcUrls: {
-      default: { http: ['https://api.testnet.hiro.so'] },
-      public: { http: ['https://api.testnet.hiro.so'] },
+      default: { http: ['https://soroban-testnet.stellar.org'] },
+      public: { http: ['https://soroban-testnet.stellar.org'] },
     },
     blockExplorers: {
-      default: { name: 'Stacks Explorer', url: 'https://explorer.hiro.so?chain=testnet' },
+      default: { name: 'Stellar Expert', url: 'https://stellar.expert/explorer/testnet' },
     },
   },
 };
 
+export const SUPPORTED_NETWORK_IDS = [
+  stellarNetworks.mainnet.id,
+  stellarNetworks.testnet.id,
+] as const;
+
+export type SupportedNetworkId = (typeof SUPPORTED_NETWORK_IDS)[number];
+
 export const appKitMetadata = {
   name: 'Predinex',
-  description: 'Decentralized Prediction Markets on Stacks',
+  description: 'Decentralized Prediction Markets on Stellar',
   url: 'https://predinex.io',
   icons: ['https://avatars.githubusercontent.com/u/179229932'],
 };

--- a/web/lib/hooks/useNetworkMismatch.ts
+++ b/web/lib/hooks/useNetworkMismatch.ts
@@ -2,7 +2,7 @@
 
 import { useAppKitNetwork } from '@reown/appkit/react';
 import { getRuntimeConfig } from '@/app/lib/runtime-config';
-import { stacksNetworks } from '@/lib/appkit-config';
+import { stellarNetworks } from '@/lib/appkit-config';
 import { useCallback, useMemo } from 'react';
 
 /**
@@ -12,23 +12,25 @@ import { useCallback, useMemo } from 'react';
 export function useNetworkMismatch() {
   const { caipNetwork, switchNetwork } = useAppKitNetwork();
   const config = getRuntimeConfig();
-  
+
   // expectedNetwork is 'mainnet' or 'testnet' from NEXT_PUBLIC_NETWORK
   const expectedNetworkType = config.network;
-  
-  // caipNetwork?.id is usually 'stacks:mainnet' or 'stacks:testnet'
+
+  // caipNetwork?.id is a CAIP-2 chain id, e.g. 'stellar:pubnet' or 'stellar:testnet'
   const currentNetworkId = caipNetwork?.id;
-  const expectedNetworkId = expectedNetworkType === 'mainnet' ? 'stacks:mainnet' : 'stacks:testnet';
-  
+  const expectedNetworkId =
+    expectedNetworkType === 'mainnet' ? stellarNetworks.mainnet.id : stellarNetworks.testnet.id;
+
   const isMismatch = useMemo(() => {
     if (!currentNetworkId) return false;
     return currentNetworkId !== expectedNetworkId;
   }, [currentNetworkId, expectedNetworkId]);
 
   const handleSwitchNetwork = useCallback(async () => {
-    const targetNetwork = expectedNetworkType === 'mainnet' ? stacksNetworks.mainnet : stacksNetworks.testnet;
+    const targetNetwork =
+      expectedNetworkType === 'mainnet' ? stellarNetworks.mainnet : stellarNetworks.testnet;
     try {
-      await (switchNetwork as any)(targetNetwork);
+      await (switchNetwork as unknown as (n: typeof targetNetwork) => Promise<void>)(targetNetwork);
     } catch (error) {
       console.error('Failed to switch network:', error);
       throw error;
@@ -38,7 +40,8 @@ export function useNetworkMismatch() {
   return {
     isMismatch,
     expectedNetworkType,
-    expectedNetworkName: expectedNetworkType === 'mainnet' ? 'Stacks Mainnet' : 'Stacks Testnet',
+    expectedNetworkName:
+      expectedNetworkType === 'mainnet' ? stellarNetworks.mainnet.name : stellarNetworks.testnet.name,
     currentNetworkName: caipNetwork?.name || 'Unknown',
     switchNetwork: handleSwitchNetwork,
   };

--- a/web/providers/AppKitProvider.tsx
+++ b/web/providers/AppKitProvider.tsx
@@ -3,14 +3,18 @@
 import { createAppKit } from '@reown/appkit/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
-import { WALLETCONNECT_PROJECT_ID, stacksNetworks, appKitMetadata } from '../lib/appkit-config';
+import { WALLETCONNECT_PROJECT_ID, stellarNetworks, appKitMetadata } from '../lib/appkit-config';
 
 const queryClient = new QueryClient();
 
-// Initialize AppKit
+// Initialize AppKit against Stellar networks. AppKit's typed `networks` field
+// expects its built-in CaipNetwork union; Stellar is configured as a CAIP-2
+// network here, so we cast to the runtime shape AppKit accepts.
 createAppKit({
   projectId: WALLETCONNECT_PROJECT_ID,
-  networks: [stacksNetworks.mainnet, stacksNetworks.testnet] as any,
+  networks: [stellarNetworks.mainnet, stellarNetworks.testnet] as unknown as Parameters<
+    typeof createAppKit
+  >[0]['networks'],
   metadata: appKitMetadata,
   features: {
     analytics: true,

--- a/web/tests/lib/appkit-config.test.ts
+++ b/web/tests/lib/appkit-config.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  stellarNetworks,
+  SUPPORTED_NETWORK_IDS,
+  appKitMetadata,
+  WALLETCONNECT_PROJECT_ID,
+} from '@/lib/appkit-config';
+
+describe('appkit-config — issue #210', () => {
+  it('exposes only Stellar CAIP-2 chain ids', () => {
+    expect(stellarNetworks.mainnet.id).toBe('stellar:pubnet');
+    expect(stellarNetworks.testnet.id).toBe('stellar:testnet');
+    expect(SUPPORTED_NETWORK_IDS).toEqual(['stellar:pubnet', 'stellar:testnet']);
+  });
+
+  it('does not export any Stacks chain ids in active config', () => {
+    const serialized = JSON.stringify(stellarNetworks).toLowerCase();
+    expect(serialized).not.toContain('stacks:mainnet');
+    expect(serialized).not.toContain('stacks:testnet');
+    for (const net of Object.values(stellarNetworks)) {
+      expect(net.chainNamespace).toBe('stellar');
+      expect(net.id.startsWith('stellar:')).toBe(true);
+      expect(net.nativeCurrency.symbol).toBe('XLM');
+    }
+  });
+
+  it('uses Stellar RPC endpoints (no Hiro/Stacks RPC URLs)', () => {
+    for (const net of Object.values(stellarNetworks)) {
+      for (const url of net.rpcUrls.default.http) {
+        expect(url).not.toContain('hiro.so');
+        expect(url).not.toContain('stacks');
+      }
+      expect(net.blockExplorers.default.url).toContain('stellar.expert');
+    }
+  });
+
+  it('keeps WalletConnect project id and metadata exported', () => {
+    expect(typeof WALLETCONNECT_PROJECT_ID).toBe('string');
+    expect(WALLETCONNECT_PROJECT_ID.length).toBeGreaterThan(0);
+    expect(appKitMetadata.name).toBe('Predinex');
+    expect(appKitMetadata.description.toLowerCase()).toContain('stellar');
+  });
+});

--- a/web/tests/lib/hooks/useNetworkMismatch.test.ts
+++ b/web/tests/lib/hooks/useNetworkMismatch.test.ts
@@ -14,9 +14,9 @@ vi.mock('@/app/lib/runtime-config', () => ({
 }));
 
 vi.mock('@/lib/appkit-config', () => ({
-  stacksNetworks: {
-    mainnet: { id: 'stacks:mainnet', name: 'Stacks Mainnet' },
-    testnet: { id: 'stacks:testnet', name: 'Stacks Testnet' },
+  stellarNetworks: {
+    mainnet: { id: 'stellar:pubnet', name: 'Stellar Mainnet' },
+    testnet: { id: 'stellar:testnet', name: 'Stellar Testnet' },
   },
 }));
 
@@ -27,7 +27,7 @@ describe('useNetworkMismatch', () => {
 
   it('returns isMismatch: false when networks match (testnet)', () => {
     vi.mocked(AppKitReact.useAppKitNetwork).mockReturnValue({
-      caipNetwork: { id: 'stacks:testnet', name: 'Stacks Testnet' },
+      caipNetwork: { id: 'stellar:testnet', name: 'Stellar Testnet' },
       switchNetwork: vi.fn(),
     } as any);
 
@@ -39,11 +39,12 @@ describe('useNetworkMismatch', () => {
 
     expect(result.current.isMismatch).toBe(false);
     expect(result.current.expectedNetworkType).toBe('testnet');
+    expect(result.current.expectedNetworkName).toBe('Stellar Testnet');
   });
 
   it('returns isMismatch: true when networks mismatch (wallet on mainnet, app on testnet)', () => {
     vi.mocked(AppKitReact.useAppKitNetwork).mockReturnValue({
-      caipNetwork: { id: 'stacks:mainnet', name: 'Stacks Mainnet' },
+      caipNetwork: { id: 'stellar:pubnet', name: 'Stellar Mainnet' },
       switchNetwork: vi.fn(),
     } as any);
 
@@ -55,7 +56,7 @@ describe('useNetworkMismatch', () => {
 
     expect(result.current.isMismatch).toBe(true);
     expect(result.current.expectedNetworkType).toBe('testnet');
-    expect(result.current.currentNetworkName).toBe('Stacks Mainnet');
+    expect(result.current.currentNetworkName).toBe('Stellar Mainnet');
   });
 
   it('returns isMismatch: false when no wallet is connected', () => {
@@ -76,7 +77,7 @@ describe('useNetworkMismatch', () => {
   it('calls switchNetwork with correct target when switchNetwork is triggered', async () => {
     const mockSwitchNetwork = vi.fn();
     vi.mocked(AppKitReact.useAppKitNetwork).mockReturnValue({
-      caipNetwork: { id: 'stacks:mainnet', name: 'Stacks Mainnet' },
+      caipNetwork: { id: 'stellar:pubnet', name: 'Stellar Mainnet' },
       switchNetwork: mockSwitchNetwork,
     } as any);
 
@@ -88,6 +89,23 @@ describe('useNetworkMismatch', () => {
 
     await result.current.switchNetwork();
 
-    expect(mockSwitchNetwork).toHaveBeenCalledWith(expect.objectContaining({ id: 'stacks:testnet' }));
+    expect(mockSwitchNetwork).toHaveBeenCalledWith(expect.objectContaining({ id: 'stellar:testnet' }));
+  });
+
+  it('returns the Stellar Mainnet expected name when app is configured for mainnet', () => {
+    vi.mocked(AppKitReact.useAppKitNetwork).mockReturnValue({
+      caipNetwork: { id: 'stellar:pubnet', name: 'Stellar Mainnet' },
+      switchNetwork: vi.fn(),
+    } as any);
+
+    vi.mocked(RuntimeConfig.getRuntimeConfig).mockReturnValue({
+      network: 'mainnet',
+    } as any);
+
+    const { result } = renderHook(() => useNetworkMismatch());
+
+    expect(result.current.isMismatch).toBe(false);
+    expect(result.current.expectedNetworkType).toBe('mainnet');
+    expect(result.current.expectedNetworkName).toBe('Stellar Mainnet');
   });
 });

--- a/web/tests/providers/AppKitProvider.test.tsx
+++ b/web/tests/providers/AppKitProvider.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+// Capture the config that AppKitProvider passes into createAppKit so we can
+// inspect it. The provider calls createAppKit at module load time, so we have
+// to install the mock before the provider import is evaluated.
+const createAppKitMock = vi.fn();
+
+vi.mock('@reown/appkit/react', () => ({
+  createAppKit: (...args: unknown[]) => createAppKitMock(...args),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  QueryClient: class {},
+  QueryClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('AppKitProvider — issue #210', () => {
+  beforeEach(() => {
+    createAppKitMock.mockReset();
+    vi.resetModules();
+  });
+
+  it('initializes AppKit without any Stacks chain ids', async () => {
+    await import('@/providers/AppKitProvider');
+
+    expect(createAppKitMock).toHaveBeenCalledTimes(1);
+    const config = createAppKitMock.mock.calls[0][0];
+
+    const networks = config.networks as Array<{ id: string; chainNamespace?: string; name?: string }>;
+    expect(Array.isArray(networks)).toBe(true);
+    expect(networks.length).toBeGreaterThan(0);
+
+    for (const n of networks) {
+      expect(n.id.startsWith('stacks:')).toBe(false);
+      expect((n.chainNamespace ?? '').toLowerCase()).not.toBe('stacks');
+      expect((n.name ?? '').toLowerCase()).not.toContain('stacks');
+    }
+
+    const serialized = JSON.stringify(networks).toLowerCase();
+    expect(serialized).not.toContain('stacks:mainnet');
+    expect(serialized).not.toContain('stacks:testnet');
+  });
+
+  it('initializes AppKit with the documented Stellar networks', async () => {
+    await import('@/providers/AppKitProvider');
+
+    const config = createAppKitMock.mock.calls[0][0];
+    const ids = (config.networks as Array<{ id: string }>).map(n => n.id).sort();
+
+    expect(ids).toEqual(['stellar:pubnet', 'stellar:testnet']);
+  });
+
+  it('renders children inside the provider', async () => {
+    const { AppKitProvider } = await import('@/providers/AppKitProvider');
+
+    const { getByText } = render(
+      <AppKitProvider>
+        <div>app-content</div>
+      </AppKitProvider>
+    );
+
+    expect(getByText('app-content')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

The AppKit provider in `web/providers/AppKitProvider.tsx` was initialising with Stacks CAIP-2 networks:

```ts
networks: [stacksNetworks.mainnet, stacksNetworks.testnet] as any,
```

Predinex runs on Stellar / Soroban now, so feeding `stacks:mainnet` / `stacks:testnet` into the provider mislabels the chain in the wallet UI (network mismatch banner, network switcher dropdown) and risks routing AppKit's account / chain events through the wrong namespace assumptions.

This PR replaces the Stacks chain ids in the active AppKit configuration with Stellar CAIP-2 networks (`stellar:pubnet` and `stellar:testnet`) and updates the consumers of that config (`useNetworkMismatch`, `NetworkSwitcher`) accordingly. The supported networks are documented in JSDoc on `web/lib/appkit-config.ts` and covered by tests that assert the AppKit init payload contains no Stacks chain ids.

Closes #210

## Changes

- [x] `web/lib/appkit-config.ts` — replace `stacksNetworks` (with `STACKS_MAINNET`/`STACKS_TESTNET` and `stacks:*` ids) with `stellarNetworks` (CAIP-2 `stellar:pubnet` / `stellar:testnet`, Stellar Soroban RPC URLs, `stellar.expert` explorer, XLM as native currency). Remove the `@stacks/network` import. Add `SUPPORTED_NETWORK_IDS` and document the supported networks in JSDoc.
- [x] `web/providers/AppKitProvider.tsx` — pass `stellarNetworks.*` to `createAppKit`. Drop the loose `as any` cast in favour of a narrower runtime cast.
- [x] `web/lib/hooks/useNetworkMismatch.ts` — compare `caipNetwork.id` against the Stellar ids and surface "Stellar Mainnet/Testnet" in the warning banner.
- [x] `web/app/components/NetworkSwitcher.tsx` — switch to `stellarNetworks` and remove the `@ts-expect-error` comment by using a narrower cast.
- [x] `web/tests/lib/hooks/useNetworkMismatch.test.ts` — update mocks/assertions to match Stellar ids; add a mainnet-config case.
- [x] **NEW** `web/tests/providers/AppKitProvider.test.tsx` — assert `createAppKit` is called with networks containing no Stacks chain ids and exactly the two documented Stellar ids.
- [x] **NEW** `web/tests/lib/appkit-config.test.ts` — assert `stellarNetworks` exposes only Stellar CAIP ids, uses Stellar RPC endpoints (no Hiro/Stacks), and that metadata is intact.

## Testing

Commands run from `web/`:

- `npm test -- --run tests/lib/hooks/useNetworkMismatch.test.ts tests/lib/appkit-config.test.ts tests/providers/AppKitProvider.test.tsx` — **12 tests passed (3 files)**.
- `npm test -- --run` — full suite: **169 tests passed**, the same **7 pre-existing failures** in `tests/components/CreateMarket.test.tsx`, `tests/components/SessionConsistency.test.tsx`, and `tests/lib/formatting.test.ts` (missing modules / stale imports unrelated to this issue). Baseline before this PR was 161 passing tests; this PR adds 8 new passing tests with no new failures.
- `npm run lint` — pre-existing 3 errors in `app/components/BettingSection.tsx` and `tests/components/CreateMarket.test.tsx` (untouched). No new errors introduced.
- `npx tsc --noEmit` — total error count **dropped from 65 → 58** (the previous `as any` in `AppKitProvider` and `@ts-expect-error` in `NetworkSwitcher` are gone). No new errors introduced.

### Manual verification

- Searched the active AppKit config for Stacks references — the only remaining `stacks:` strings are in untouched files (`app/lib/walletconnect-config.ts`, `WalletConnectButton`, etc.) outside the AppKit provider configuration scope of this issue.
- The new `tests/providers/AppKitProvider.test.tsx` instantiates the provider for real, captures the `createAppKit` payload, and asserts no Stacks chain ids remain — i.e. covers the issue's "Run provider-related tests and verify no Stacks network objects remain in the active setup" acceptance criterion.

## Acceptance criteria mapping

- [x] **AppKit configuration no longer depends on Stacks chain ids in production paths** — `AppKitProvider`, `appkit-config`, `useNetworkMismatch`, and `NetworkSwitcher` all use Stellar CAIP-2 networks.
- [x] **Supported network configuration is documented and tested** — JSDoc on `web/lib/appkit-config.ts`, plus the new `appkit-config.test.ts` and `AppKitProvider.test.tsx` test files.
- [x] **The provider still initializes cleanly after the change** — covered by `tests/providers/AppKitProvider.test.tsx` (it asserts `createAppKit` is called once, with the expected Stellar networks, and that the provider renders its children).

## Notes / follow-ups

- AppKit does not currently ship a first-party Stellar adapter, so the Stellar networks are passed as plain CAIP-2 descriptors (the same pattern the Stacks objects used). The narrow runtime cast is documented inline.
- Other Stacks references remain in the codebase (`app/lib/walletconnect-config.ts`, `wallet-service.ts`, `stacks-api.ts`, etc.) — those are intentionally out of scope for this issue, which targets the AppKit provider configuration specifically. Follow-up issues can address them.
- The 7 pre-existing test failures and 3 lint errors are unrelated to this change and exist on `main`.