### PR TITLE
Feat/protocol fee config and event enrichment

### DIFF
--- a/contracts/predinex/src/lib.rs
+++ b/contracts/predinex/src/lib.rs
@@ -2,6 +2,7 @@
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, String, Symbol, Vec};
 
 mod test;
+mod protocol_fee_tests;
 
 #[derive(Clone)]
 #[contracttype]
@@ -17,6 +18,9 @@ pub enum DataKey {
     /// #179 — per-pool creation fee in stroops. Set by the admin via
     /// `set_creation_fee`; defaults to 0 (no fee) when absent.
     CreationFee,
+    /// #167 — protocol fee in basis points. Set by the treasury recipient via
+    /// `set_protocol_fee`; defaults to 200 (2%) when absent.
+    ProtocolFee,
 }
 
 // #189 — TTL bump policy for persistent storage entries.
@@ -31,6 +35,14 @@ pub enum DataKey {
 const LEDGERS_PER_DAY: u32 = 17_280;
 const POOL_BUMP_TARGET: u32 = LEDGERS_PER_DAY * 30; // extend to 30 days
 const POOL_BUMP_THRESHOLD: u32 = LEDGERS_PER_DAY * 25; // trigger bump when < 25 days remain
+
+/// #167 — Protocol fee bounds in basis points.
+/// Minimum fee: 0 (0%) — no fee floor, allows fee-free operation.
+/// Maximum fee: 1000 (10%) — protects users from excessive fees.
+/// Default fee: 200 (2%) — matches the original hard-coded value.
+const PROTOCOL_FEE_MIN_BPS: u32 = 0;
+const PROTOCOL_FEE_MAX_BPS: u32 = 1000;
+const PROTOCOL_FEE_DEFAULT_BPS: u32 = 200;
 
 /// Explicit lifecycle status for a prediction pool.
 ///
@@ -153,6 +165,27 @@ pub struct BetEvent {
     pub total_bet: i128,
 }
 
+/// #169 — Event payload emitted by `create_pool`.
+///
+/// Fields
+/// ------\n/// - `creator`        – address that created the pool
+/// - `expiry`         – unix timestamp when the pool expires
+/// - `title`          – short market title
+/// - `outcome_a_name` – label for outcome A
+/// - `outcome_b_name` – label for outcome B
+///
+/// This payload allows indexers to populate a lightweight market list entry
+/// without performing follow-up reads for every new pool.
+#[derive(Clone)]
+#[contracttype]
+pub struct CreatePoolEvent {
+    pub creator: Address,
+    pub expiry: u64,
+    pub title: String,
+    pub outcome_a_name: String,
+    pub outcome_b_name: String,
+}
+
 #[contract]
 pub struct PredinexContract;
 
@@ -195,6 +228,56 @@ impl PredinexContract {
             .persistent()
             .get::<_, i128>(&DataKey::CreationFee)
             .unwrap_or(0)
+    }
+
+    /// #167 — Set the protocol fee in basis points.
+    ///
+    /// Only the treasury recipient may call this. The fee must be within
+    /// [PROTOCOL_FEE_MIN_BPS, PROTOCOL_FEE_MAX_BPS] (0–1000 basis points, i.e., 0–10%).
+    /// The fee applies to future settlements and claims; existing settled pools
+    /// are not affected.
+    ///
+    /// # Arguments
+    /// * `caller` – must be the current treasury recipient
+    /// * `fee_bps` – new fee in basis points (1 bp = 0.01%)
+    ///
+    /// # Panics
+    /// * "Unauthorized" – if caller is not the treasury recipient
+    /// * "Fee out of bounds" – if fee_bps is outside [0, 1000]
+    pub fn set_protocol_fee(env: Env, caller: Address, fee_bps: u32) {
+        caller.require_auth();
+        let treasury_recipient: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TreasuryRecipient)
+            .expect("Not initialized");
+        if caller != treasury_recipient {
+            panic!("Unauthorized");
+        }
+        if fee_bps < PROTOCOL_FEE_MIN_BPS || fee_bps > PROTOCOL_FEE_MAX_BPS {
+            panic!("Fee out of bounds");
+        }
+        env.storage().persistent().set(&DataKey::ProtocolFee, &fee_bps);
+
+        env.events().publish(
+            (Symbol::new(&env, "protocol_fee_set"),),
+            (caller, fee_bps),
+        );
+    }
+
+    /// #166 — Return the current protocol fee in basis points.
+    ///
+    /// The returned value is the canonical source of truth for fee display
+    /// in frontends and analytics. Use `get_protocol_fee` to preview fees
+    /// before placing bets or claiming winnings.
+    ///
+    /// # Returns
+    /// The protocol fee in basis points (default: 200 = 2%).
+    pub fn get_protocol_fee(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get::<_, u32>(&DataKey::ProtocolFee)
+            .unwrap_or(PROTOCOL_FEE_DEFAULT_BPS)
     }
 
     /// Normalize a Soroban `String` to a comparable form by converting to
@@ -273,10 +356,10 @@ impl PredinexContract {
 
         let pool = Pool {
             creator: creator.clone(),
-            title,
+            title: title.clone(),
             description,
-            outcome_a_name: outcome_a,
-            outcome_b_name: outcome_b,
+            outcome_a_name: outcome_a.clone(),
+            outcome_b_name: outcome_b.clone(),
             total_a: 0,
             total_b: 0,
             participant_count: 0,
@@ -301,9 +384,16 @@ impl PredinexContract {
             .persistent()
             .set(&DataKey::PoolCounter, &(pool_id + 1));
 
+        // #169 — emit enriched create_pool event with expiry and metadata summary
         env.events().publish(
             (Symbol::new(&env, "create_pool"), pool_id),
-            (creator, Symbol::new(&env, "Open")),
+            CreatePoolEvent {
+                creator: creator.clone(),
+                expiry,
+                title,
+                outcome_a_name: outcome_a,
+                outcome_b_name: outcome_b,
+            },
         );
 
         pool_id
@@ -509,13 +599,15 @@ impl PredinexContract {
         pool.winning_outcome = Some(winning_outcome);
 
         // #171 — compute totals for the enriched settlement event.
+        // #167 — use configurable protocol fee instead of hard-coded 2%.
         let winning_side_total = if winning_outcome == 0 {
             pool.total_a
         } else {
             pool.total_b
         };
         let total_pool_volume = pool.total_a + pool.total_b;
-        let fee_amount = (total_pool_volume * 2) / 100;
+        let fee_bps = Self::get_protocol_fee(env.clone()) as i128;
+        let fee_amount = (total_pool_volume * fee_bps) / 10000;
 
         env.storage()
             .persistent()
@@ -675,7 +767,8 @@ impl PredinexContract {
         };
         let total_pool_balance = pool.total_a + pool.total_b;
 
-        let fee = (total_pool_balance * 2) / 100;
+        let fee_bps = Self::get_protocol_fee(env.clone()) as i128;
+        let fee = (total_pool_balance * fee_bps) / 10000;
         let net_pool_balance = total_pool_balance - fee;
 
         let winnings = (user_winning_bet * net_pool_balance) / pool_winning_total;

--- a/contracts/predinex/src/protocol_fee_tests.rs
+++ b/contracts/predinex/src/protocol_fee_tests.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String};
 
 fn setup_contract() -> (Env, PredinexContractClient<'static>, Address, Address) {
     let env = Env::default();
@@ -11,7 +11,6 @@ fn setup_contract() -> (Env, PredinexContractClient<'static>, Address, Address) 
 
     let token_admin = Address::generate(&env);
     let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
-    let token_admin_client = token::StellarAssetClient::new(&env, &token_id.address());
 
     client.initialize(&token_id.address(), &token_admin);
 
@@ -23,14 +22,14 @@ fn setup_contract() -> (Env, PredinexContractClient<'static>, Address, Address) 
 
 #[test]
 fn test_get_protocol_fee_returns_default() {
-    let (env, client, _, _) = setup_contract();
+    let (_env, client, _, _) = setup_contract();
     let fee = client.get_protocol_fee();
     assert_eq!(fee, 200, "default fee should be 200 basis points (2%)");
 }
 
 #[test]
 fn test_set_protocol_fee_within_bounds() {
-    let (env, client, admin, _) = setup_contract();
+    let (_env, client, admin, _) = setup_contract();
     client.set_protocol_fee(&admin, &500);
     assert_eq!(client.get_protocol_fee(), 500);
 }
@@ -38,13 +37,13 @@ fn test_set_protocol_fee_within_bounds() {
 #[test]
 #[should_panic(expected = "Fee out of bounds")]
 fn test_set_protocol_fee_above_max_rejected() {
-    let (env, client, admin, _) = setup_contract();
+    let (_env, client, admin, _) = setup_contract();
     client.set_protocol_fee(&admin, &1001);
 }
 
 #[test]
 fn test_set_protocol_fee_at_boundaries() {
-    let (env, client, admin, _) = setup_contract();
+    let (_env, client, admin, _) = setup_contract();
     client.set_protocol_fee(&admin, &0);
     assert_eq!(client.get_protocol_fee(), 0);
     client.set_protocol_fee(&admin, &1000);
@@ -82,15 +81,15 @@ fn test_claim_winnings_uses_configured_fee() {
 
 #[test]
 fn test_create_pool_event_includes_metadata() {
-    let (env, client, admin, _) = setup_contract();
-    let creator = Address::generate(&env);
+    let (_env, client, _admin, _) = setup_contract();
+    let creator = Address::generate(&_env);
 
     let pool_id = client.create_pool(
         &creator,
-        &String::from_str(&env, "Test Market"),
-        &String::from_str(&env, "Description"),
-        &String::from_str(&env, "Yes"),
-        &String::from_str(&env, "No"),
+        &String::from_str(&_env, "Test Market"),
+        &String::from_str(&_env, "Description"),
+        &String::from_str(&_env, "Yes"),
+        &String::from_str(&_env, "No"),
         &3600,
     );
 

--- a/contracts/predinex/src/protocol_fee_tests.rs
+++ b/contracts/predinex/src/protocol_fee_tests.rs
@@ -1,0 +1,98 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup_contract() -> (Env, PredinexContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PredinexContract, ());
+    let client = PredinexContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id.address());
+
+    client.initialize(&token_id.address(), &token_admin);
+
+    let client: PredinexContractClient<'static> = unsafe { core::mem::transmute(client) };
+    let env: Env = unsafe { core::mem::transmute(env) };
+
+    (env, client, token_admin, token_id.address())
+}
+
+#[test]
+fn test_get_protocol_fee_returns_default() {
+    let (env, client, _, _) = setup_contract();
+    let fee = client.get_protocol_fee();
+    assert_eq!(fee, 200, "default fee should be 200 basis points (2%)");
+}
+
+#[test]
+fn test_set_protocol_fee_within_bounds() {
+    let (env, client, admin, _) = setup_contract();
+    client.set_protocol_fee(&admin, &500);
+    assert_eq!(client.get_protocol_fee(), 500);
+}
+
+#[test]
+#[should_panic(expected = "Fee out of bounds")]
+fn test_set_protocol_fee_above_max_rejected() {
+    let (env, client, admin, _) = setup_contract();
+    client.set_protocol_fee(&admin, &1001);
+}
+
+#[test]
+fn test_set_protocol_fee_at_boundaries() {
+    let (env, client, admin, _) = setup_contract();
+    client.set_protocol_fee(&admin, &0);
+    assert_eq!(client.get_protocol_fee(), 0);
+    client.set_protocol_fee(&admin, &1000);
+    assert_eq!(client.get_protocol_fee(), 1000);
+}
+
+#[test]
+fn test_claim_winnings_uses_configured_fee() {
+    let (env, client, admin, token) = setup_contract();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token);
+    
+    client.set_protocol_fee(&admin, &500);
+
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+    token_admin_client.mint(&user, &1000);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Market"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Yes"),
+        &String::from_str(&env, "No"),
+        &3600,
+    );
+
+    client.place_bet(&user, &pool_id, &0, &100);
+
+    env.ledger().with_mut(|li| li.timestamp = 3601);
+    client.settle_pool(&creator, &pool_id, &0);
+
+    let winnings = client.claim_winnings(&user, &pool_id);
+    assert_eq!(winnings, 95);
+}
+
+#[test]
+fn test_create_pool_event_includes_metadata() {
+    let (env, client, admin, _) = setup_contract();
+    let creator = Address::generate(&env);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Test Market"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Yes"),
+        &String::from_str(&env, "No"),
+        &3600,
+    );
+
+    assert_eq!(pool_id, 1);
+}

--- a/contracts/predinex/test_snapshots/protocol_fee_tests/test_get_protocol_fee_returns_default.1.json
+++ b/contracts/predinex/test_snapshots/protocol_fee_tests/test_get_protocol_fee_returns_default.1.json
@@ -1,0 +1,389 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "account": {
+            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "account": {
+                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+                "balance": 0,
+                "seq_num": 0,
+                "num_sub_entries": 0,
+                "inflation_dest": null,
+                "flags": 0,
+                "home_domain": "",
+                "thresholds": "01010101",
+                "signers": [],
+                "ext": "v0"
+              }
+            },
+            "ext": "v0"
+          },
+          null
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Token"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Token"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Treasury"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Treasury"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 0
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "TreasuryRecipient"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "TreasuryRecipient"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": "stellar_asset",
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "METADATA"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "decimal"
+                              },
+                              "val": {
+                                "u32": 7
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "aaa"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AssetInfo"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "AlphaNum4"
+                            },
+                            {
+                              "map": [
+                                {
+                                  "key": {
+                                    "symbol": "asset_code"
+                                  },
+                                  "val": {
+                                    "string": "aaa\\0"
+                                  }
+                                },
+                                {
+                                  "key": {
+                                    "symbol": "issuer"
+                                  },
+                                  "val": {
+                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          120960
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/web/FRONTEND.md
+++ b/web/FRONTEND.md
@@ -3,19 +3,18 @@
 ## Overview
 Predinex is a decentralized prediction market built on the **Stellar blockchain** (via Soroban). The frontend is a modern Next.js application that prioritizes performance, type safety, and a premium user experience in the Stellar ecosystem.
 
-> [!IMPORTANT]
-> **Migration in Progress**: This frontend is currently being migrated from a Stacks-based architecture to a full Stellar/Soroban implementation. Some internal component names and libraries (e.g., `StacksProvider`) are legacy artifacts that are being systematically replaced by Stellar SDK and Freighter integrations.
-
 ## Tech Stack
-- **Framework**: Next.js 14 (App Router)
-- **Styling**: Tailwind CSS
+- **Framework**: Next.js 16 (App Router)
+- **React**: React 19
+- **Styling**: Tailwind CSS 4
 - **Blockchain Interop**: Stellar SDK, Soroban integration
 - **Wallet Connection**: Freighter, WalletConnect
 - **Icons**: Lucide React
-- **State Management**: React Context (Legacy: `StacksProvider`, migrating to `StellarProvider`)
+- **State Management**: React Context
+- **Testing**: Vitest with React Testing Library
 
 ## Core Components
-- **StellarProvider (Legacy: StacksProvider)**: Manages authentication and wallet state for the Stellar network.
+- **Wallet Providers**: Manages authentication and wallet state for the Stellar network.
 - **Navbar**: Main navigation and Stellar wallet connection status.
 - **Hero**: Institutional-grade landing section featuring Stellar-themed aesthetics.
 - **MarketCard**: Detailed representation of individual prediction markets on Soroban.
@@ -23,18 +22,20 @@ Predinex is a decentralized prediction market built on the **Stellar blockchain*
 - **Rewards**: Leaderboard and incentive tracking.
 
 ## Directory Structure
-- `app/`: Next.js pages and layouts.
-- `components/`: Reusable UI components.
-- `lib/`: Core logic, services, and utilities (migrating and legacy).
+- `app/`: Next.js 16 pages, layouts, and route handlers.
+- `app/components/`: Page-specific UI components.
+- `components/`: Shared reusable UI components.
+- `lib/`: Core logic, services, and utilities.
 - `providers/`: Context providers for global state.
-- `styles/`: Global CSS and Tailwind configuration.
+- `tests/`: Vitest test suites for components and utilities.
+- `public/`: Static assets.
 
 ## Component Documentation
 
 ### Layout Components
 - **Navbar**: Responsive navigation with mobile menu support. Handles the primary Stellar wallet connection.
 - **Footer**: Professional footer with social links, legal info, and Stellar ecosystem overview.
-- **StellarProvider**: Context provider that wraps the application to provide wallet authentication state.
+- **Wallet Providers**: Context providers that wrap the application to provide wallet authentication state.
 
 ### Dashboard Components
 - **PortfolioOverview**: High-level summary of user earnings, wagered amounts (XLM), and profit/loss.
@@ -71,7 +72,7 @@ The frontend interacts with Soroban smart contracts using the Stellar SDK.
 ## Styling and Design System
 
 ### Tailwind CSS
-We use Tailwind CSS for all component styling, leveraging a custom theme that provides a cohesive institutional aesthetic.
+We use Tailwind CSS 4 for all component styling, leveraging a custom theme that provides a cohesive institutional aesthetic.
 
 **Core Design Principles:**
 - **Glassmorphism**: Extensive use of `backdrop-blur` and semi-transparent backgrounds.


### PR DESCRIPTION
Closes #166 - Contract exposes protocol fee via get_protocol_fee() read method returning basis points

Closes #167 - Protocol fee is now configurable via set_protocol_fee() with bounds 0-1000 bps (0-10%), emits events, and applies to future claims

Closes #169 - Create pool events now include enriched metadata (creator, expiry, title, outcome names) via CreatePoolEvent struct

Closes #226 - FRONTEND.md updated to reflect Next.js 16, React 19, Tailwind CSS 4, current folder structure, and removed migration notes

