### PR TITLE
feat(contract): per-pool protocol revenue and treasury attribution (#…

### DIFF
--- a/contracts/predinex/src/lib.rs
+++ b/contracts/predinex/src/lib.rs
@@ -1,9 +1,9 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, String, Symbol, Vec};
 
-mod test;
-mod protocol_fee_tests;
 mod pause_tests;
+mod protocol_fee_tests;
+mod test;
 
 // ── Issue #175: Event schema versioning ──────────────────────────────────────
 //
@@ -52,6 +52,12 @@ pub enum DataKey {
     /// #167 — protocol fee in basis points. Set by the treasury recipient via
     /// `set_protocol_fee`; defaults to 200 (2%) when absent.
     ProtocolFee,
+    /// #158 — per-pool claim / payout progress for winner claims.
+    PoolPayoutState(u32),
+    /// #195 — floor(bps × pool volume) protocol fee for this market (set at settlement).
+    PoolSettlementProtocolFee(u32),
+    /// #195 — running total credited to aggregate `Treasury` from this pool (fee + dust).
+    PoolTreasuryCredited(u32),
 }
 
 // #189 — TTL bump policy for persistent storage entries.
@@ -74,6 +80,11 @@ const POOL_BUMP_THRESHOLD: u32 = LEDGERS_PER_DAY * 25; // trigger bump when < 25
 const PROTOCOL_FEE_MIN_BPS: u32 = 0;
 const PROTOCOL_FEE_MAX_BPS: u32 = 1000;
 const PROTOCOL_FEE_DEFAULT_BPS: u32 = 200;
+
+/// #151 — Minimum pool lifetime in seconds (matches `web/docs/POOL_DURATION.md`).
+const MIN_POOL_DURATION_SECS: u64 = 300;
+/// #151 — Maximum pool lifetime in seconds (matches web validators / tests).
+const MAX_POOL_DURATION_SECS: u64 = 1_000_000;
 
 /// Explicit lifecycle status for a prediction pool.
 ///
@@ -240,6 +251,39 @@ pub struct CreatePoolEvent {
     pub outcome_b_name: String,
 }
 
+/// #158 — Tracks cumulative winner claims and whether the protocol fee was
+/// credited to the treasury for this pool.
+#[derive(Clone, Default)]
+#[contracttype]
+pub struct PoolPayoutState {
+    pub claimed_winning_stake: i128,
+    pub paid_out: i128,
+    pub fee_credited: bool,
+}
+
+/// Event payload emitted by `claim_winnings`.
+#[derive(Clone)]
+#[contracttype]
+pub struct ClaimEvent {
+    pub amount: i128,
+    pub fee_amount: i128,
+    pub winning_outcome: u32,
+    pub total_pool_size: i128,
+}
+
+/// #195 — Pool-level protocol revenue exposed for analytics and audits.
+///
+/// `settlement_protocol_fee` is the bps fee amount fixed when the pool is
+/// settled (same value emitted on the `settle_pool` event). `treasury_credited`
+/// increases as winners claim: protocol fee on the first winner claim, plus
+/// payout rounding dust on the final claim — mirroring aggregate `Treasury`.
+#[derive(Clone)]
+#[contracttype]
+pub struct PoolProtocolRevenue {
+    pub settlement_protocol_fee: i128,
+    pub treasury_credited: i128,
+}
+
 #[contract]
 pub struct PredinexContract;
 
@@ -308,15 +352,15 @@ impl PredinexContract {
         if caller != treasury_recipient {
             panic!("Unauthorized");
         }
-        if fee_bps < PROTOCOL_FEE_MIN_BPS || fee_bps > PROTOCOL_FEE_MAX_BPS {
+        if !(PROTOCOL_FEE_MIN_BPS..=PROTOCOL_FEE_MAX_BPS).contains(&fee_bps) {
             panic!("Fee out of bounds");
         }
-        env.storage().persistent().set(&DataKey::ProtocolFee, &fee_bps);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProtocolFee, &fee_bps);
 
-        env.events().publish(
-            (Symbol::new(&env, "protocol_fee_set"),),
-            (caller, fee_bps),
-        );
+        env.events()
+            .publish((Symbol::new(&env, "protocol_fee_set"),), (caller, fee_bps));
     }
 
     /// #166 — Return the current protocol fee in basis points.
@@ -378,8 +422,8 @@ impl PredinexContract {
         s.copy_into_slice(&mut buf[..copy_len]);
 
         let mut has_non_whitespace = false;
-        for i in 0..copy_len {
-            if buf[i] != b' ' && buf[i] != b'\t' && buf[i] != b'\n' && buf[i] != b'\r' {
+        for b in buf.iter().take(copy_len) {
+            if *b != b' ' && *b != b'\t' && *b != b'\n' && *b != b'\r' {
                 has_non_whitespace = true;
                 break;
             }
@@ -400,6 +444,11 @@ impl PredinexContract {
         duration: u64,
     ) -> u32 {
         creator.require_auth();
+
+        Self::validate_non_empty_string(&title);
+        Self::validate_non_empty_string(&description);
+        Self::validate_non_empty_string(&outcome_a);
+        Self::validate_non_empty_string(&outcome_b);
 
         // #151 — Reject pools below the minimum duration before any state
         // writes or fee transfers, so a rejection leaves the contract
@@ -439,8 +488,8 @@ impl PredinexContract {
 
         let pool_id = Self::get_pool_counter(&env);
 
-        if duration == 0 || duration > MAX_POOL_DURATION {
-            panic!(format!("Duration must be between 1 and {} seconds", MAX_POOL_DURATION));
+        if duration > MAX_POOL_DURATION_SECS {
+            panic!("Duration must be between 1 and 1000000 seconds");
         }
 
         let created_at = env.ledger().timestamp();
@@ -526,9 +575,15 @@ impl PredinexContract {
         token_client.transfer(&user, &env.current_contract_address(), &amount);
 
         if outcome == 0 {
-            pool.total_a = pool.total_a.checked_add(amount).expect("Pool total overflow");
+            pool.total_a = pool
+                .total_a
+                .checked_add(amount)
+                .expect("Pool total overflow");
         } else {
-            pool.total_b = pool.total_b.checked_add(amount).expect("Pool total overflow");
+            pool.total_b = pool
+                .total_b
+                .checked_add(amount)
+                .expect("Pool total overflow");
         }
 
         let mut user_bet = env
@@ -557,11 +612,20 @@ impl PredinexContract {
         );
 
         if outcome == 0 {
-            user_bet.amount_a = user_bet.amount_a.checked_add(amount).expect("User bet overflow");
+            user_bet.amount_a = user_bet
+                .amount_a
+                .checked_add(amount)
+                .expect("User bet overflow");
         } else {
-            user_bet.amount_b = user_bet.amount_b.checked_add(amount).expect("User bet overflow");
+            user_bet.amount_b = user_bet
+                .amount_b
+                .checked_add(amount)
+                .expect("User bet overflow");
         }
-        user_bet.total_bet = user_bet.total_bet.checked_add(amount).expect("User bet overflow");
+        user_bet.total_bet = user_bet
+            .total_bet
+            .checked_add(amount)
+            .expect("User bet overflow");
 
         env.storage()
             .persistent()
@@ -719,6 +783,15 @@ impl PredinexContract {
         env.storage()
             .persistent()
             .set(&DataKey::Pool(pool_id), &pool);
+        // #195 — record the market's protocol fee for pool-level reporting.
+        env.storage()
+            .persistent()
+            .set(&DataKey::PoolSettlementProtocolFee(pool_id), &fee_amount);
+        env.storage().persistent().extend_ttl(
+            &DataKey::PoolSettlementProtocolFee(pool_id),
+            POOL_BUMP_THRESHOLD,
+            POOL_BUMP_TARGET,
+        );
         // #189 — keep pool accessible for claim operations after settlement.
         env.storage().persistent().extend_ttl(
             &DataKey::Pool(pool_id),
@@ -951,23 +1024,9 @@ impl PredinexContract {
         let token_client = token::Client::new(&env, &token_address);
         token_client.transfer(&env.current_contract_address(), &user, &winnings);
 
-        // Step 3: record the fee in the treasury ledger only after the transfer succeeds.
-        let current_treasury: i128 = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Treasury)
-            .unwrap_or(0);
-        let updated_treasury = current_treasury
-            .checked_add(fee)
-            .expect("Treasury total overflow");
-        env.storage()
-            .persistent()
-            .set(&DataKey::Treasury, &updated_treasury);
-
-        // Step 4: credit the treasury ledger. The fee is added once (on the
-        // first claim) and the payout-rounding dust is added on the final
-        // claim. Both quantities also remain in the contract's token balance
-        // so `contract_balance == treasury` reconciles after the final claim.
+        // Step 3–4: credit the treasury ledger only after the transfer succeeds.
+        // The protocol fee is added once (on the first claim) and payout dust on
+        // the final claim — both remain in the contract token balance.
         let treasury_delta = (if is_first_claim { fee } else { 0 }) + payout_dust;
         if treasury_delta > 0 {
             let current_treasury: i128 = env
@@ -975,10 +1034,39 @@ impl PredinexContract {
                 .persistent()
                 .get(&DataKey::Treasury)
                 .unwrap_or(0);
+            let next_treasury = current_treasury
+                .checked_add(treasury_delta)
+                .expect("Treasury total overflow");
             env.storage()
                 .persistent()
-                .set(&DataKey::Treasury, &(current_treasury + treasury_delta));
+                .set(&DataKey::Treasury, &next_treasury);
+
+            // #195 — per-pool attribution must move in lockstep with aggregate Treasury.
+            let credit_key = DataKey::PoolTreasuryCredited(pool_id);
+            let prev_pool_credit: i128 = env.storage().persistent().get(&credit_key).unwrap_or(0);
+            let next_pool_credit = prev_pool_credit
+                .checked_add(treasury_delta)
+                .expect("Pool treasury credit overflow");
+            env.storage()
+                .persistent()
+                .set(&credit_key, &next_pool_credit);
+            env.storage().persistent().extend_ttl(
+                &credit_key,
+                POOL_BUMP_THRESHOLD,
+                POOL_BUMP_TARGET,
+            );
         }
+
+        payout_state.claimed_winning_stake = new_claimed_winning_stake;
+        payout_state.paid_out = new_paid_out;
+        if is_first_claim {
+            payout_state.fee_credited = true;
+        }
+        let payout_key = DataKey::PoolPayoutState(pool_id);
+        env.storage().persistent().set(&payout_key, &payout_state);
+        env.storage()
+            .persistent()
+            .extend_ttl(&payout_key, POOL_BUMP_THRESHOLD, POOL_BUMP_TARGET);
 
         // Step 5: remove the bet record to prevent duplicate claims.
         env.storage()
@@ -1007,6 +1095,31 @@ impl PredinexContract {
         env.storage()
             .persistent()
             .get(&DataKey::PoolPayoutState(pool_id))
+    }
+
+    /// #195 — Return per-pool protocol fee (fixed at settlement) and cumulative
+    /// treasury credits from this pool (fee + payout dust), for analytics and audits.
+    pub fn get_pool_protocol_revenue(env: Env, pool_id: u32) -> PoolProtocolRevenue {
+        let fee_key = DataKey::PoolSettlementProtocolFee(pool_id);
+        let credit_key = DataKey::PoolTreasuryCredited(pool_id);
+        if env.storage().persistent().has(&fee_key) {
+            env.storage()
+                .persistent()
+                .extend_ttl(&fee_key, POOL_BUMP_THRESHOLD, POOL_BUMP_TARGET);
+        }
+        if env.storage().persistent().has(&credit_key) {
+            env.storage().persistent().extend_ttl(
+                &credit_key,
+                POOL_BUMP_THRESHOLD,
+                POOL_BUMP_TARGET,
+            );
+        }
+        let settlement_protocol_fee: i128 = env.storage().persistent().get(&fee_key).unwrap_or(0);
+        let treasury_credited: i128 = env.storage().persistent().get(&credit_key).unwrap_or(0);
+        PoolProtocolRevenue {
+            settlement_protocol_fee,
+            treasury_credited,
+        }
     }
 
     pub fn get_treasury_balance(env: Env) -> i128 {
@@ -1492,7 +1605,8 @@ impl PredinexContract {
             pool.total_b
         };
         let total_pool_balance = pool.total_a + pool.total_b;
-        let fee = (total_pool_balance * 2) / 100;
+        let fee_bps = Self::get_protocol_fee(env.clone()) as i128;
+        let fee = (total_pool_balance * fee_bps) / 10000;
         let net_pool_balance = total_pool_balance - fee;
         let amount = (user_winning_bet * net_pool_balance) / pool_winning_total;
 

--- a/contracts/predinex/src/pause_tests.rs
+++ b/contracts/predinex/src/pause_tests.rs
@@ -7,7 +7,10 @@
 
 #![cfg(test)]
 use super::*;
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
 
 // ── Test harness ──────────────────────────────────────────────────────────────
 
@@ -40,8 +43,6 @@ impl TestCtx {
 
         let pool_creator = Address::generate(&env);
 
-        let env: Env = unsafe { core::mem::transmute(env) };
-
         TestCtx {
             env,
             client,
@@ -66,8 +67,7 @@ impl TestCtx {
 
     /// Mint tokens to `user` and place a bet on `pool_id`.
     fn fund_and_bet(&self, user: &Address, pool_id: u32, outcome: u32, amount: i128) {
-        let token_admin_client =
-            token::StellarAssetClient::new(&self.env, &self.token_id);
+        let token_admin_client = token::StellarAssetClient::new(&self.env, &self.token_id);
         token_admin_client.mint(user, &amount);
         self.client.place_bet(user, &pool_id, &outcome, &amount);
     }
@@ -75,7 +75,8 @@ impl TestCtx {
     /// Advance ledger past the pool's deadline and settle it using pool_creator.
     fn settle(&self, pool_id: u32, winning_outcome: u32) {
         self.env.ledger().with_mut(|li| li.timestamp = 7200);
-        self.client.settle_pool(&self.pool_creator, &pool_id, &winning_outcome);
+        self.client
+            .settle_pool(&self.pool_creator, &pool_id, &winning_outcome);
     }
 }
 
@@ -189,7 +190,10 @@ fn test_claim_winnings_succeeds_after_unfreeze() {
     ctx.client.unfreeze_pool(&ctx.freeze_admin, &pool_id);
     ctx.client.settle_pool(&ctx.pool_creator, &pool_id, &0);
     let payout = ctx.client.claim_winnings(&user_a, &pool_id);
-    assert!(payout > 0, "winner should receive a payout after unfreeze + re-settle");
+    assert!(
+        payout > 0,
+        "winner should receive a payout after unfreeze + re-settle"
+    );
 }
 
 // ── settle_pool: frozen pool blocks non-creator callers ───────────────────────
@@ -290,7 +294,8 @@ fn test_rotate_treasury_recipient_unaffected_by_pool_freeze() {
     ctx.client.freeze_pool(&ctx.freeze_admin, &pool_id);
 
     let new_recipient = Address::generate(&ctx.env);
-    ctx.client.rotate_treasury_recipient(&ctx.token_admin, &new_recipient);
+    ctx.client
+        .rotate_treasury_recipient(&ctx.token_admin, &new_recipient);
     let stored = ctx.client.get_treasury_recipient().unwrap();
     assert_eq!(stored, new_recipient);
 }
@@ -303,7 +308,10 @@ fn test_get_pool_readable_while_frozen() {
     let pool_id = ctx.open_pool();
     ctx.client.freeze_pool(&ctx.freeze_admin, &pool_id);
     let pool = ctx.client.get_pool(&pool_id);
-    assert!(pool.is_some(), "get_pool should return data even when frozen");
+    assert!(
+        pool.is_some(),
+        "get_pool should return data even when frozen"
+    );
 }
 
 #[test]
@@ -324,7 +332,10 @@ fn test_get_user_bet_readable_while_frozen() {
     ctx.client.freeze_pool(&ctx.freeze_admin, &pool_id);
 
     let bet = ctx.client.get_user_bet(&pool_id, &user);
-    assert!(bet.is_some(), "get_user_bet should work while pool is frozen");
+    assert!(
+        bet.is_some(),
+        "get_user_bet should work while pool is frozen"
+    );
 }
 
 // ── set_freeze_admin restrictions ─────────────────────────────────────────────

--- a/contracts/predinex/src/protocol_fee_tests.rs
+++ b/contracts/predinex/src/protocol_fee_tests.rs
@@ -1,6 +1,9 @@
 #![cfg(test)]
 use super::*;
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
 
 fn setup_contract() -> (Env, PredinexContractClient<'static>, Address, Address) {
     let env = Env::default();
@@ -15,7 +18,6 @@ fn setup_contract() -> (Env, PredinexContractClient<'static>, Address, Address) 
     client.initialize(&token_id.address(), &token_admin);
 
     let client: PredinexContractClient<'static> = unsafe { core::mem::transmute(client) };
-    let env: Env = unsafe { core::mem::transmute(env) };
 
     (env, client, token_admin, token_id.address())
 }
@@ -54,7 +56,7 @@ fn test_set_protocol_fee_at_boundaries() {
 fn test_claim_winnings_uses_configured_fee() {
     let (env, client, admin, token) = setup_contract();
     let token_admin_client = token::StellarAssetClient::new(&env, &token);
-    
+
     client.set_protocol_fee(&admin, &500);
 
     let creator = Address::generate(&env);

--- a/contracts/predinex/src/test.rs
+++ b/contracts/predinex/src/test.rs
@@ -2,9 +2,7 @@
 extern crate std;
 use super::*;
 use soroban_sdk::String;
-use soroban_sdk::{
-    testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env, IntoVal,
-};
+use soroban_sdk::{testutils::Address as _, testutils::Events, testutils::Ledger, Address, Env};
 use std::format;
 
 #[test]
@@ -127,7 +125,10 @@ fn test_large_pool_payouts_with_checked_arithmetic() {
     client.settle_pool(&creator, &pool_id, &0);
 
     let winnings = client.claim_winnings(&user1, &pool_id);
-    assert!(winnings > 0, "Large pool winnings must compute successfully");
+    assert!(
+        winnings > 0,
+        "Large pool winnings must compute successfully"
+    );
     assert_eq!(token.balance(&user1), 100 + winnings);
 }
 
@@ -166,11 +167,14 @@ fn test_place_bet_rejects_pool_total_overflow() {
     client.place_bet(&user1, &pool_id, &0, &huge_amount);
 
     // Overflow on the second bet should fail predictably.
-    let result = std::panic::catch_unwind(|| {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.place_bet(&user2, &pool_id, &0, &2);
-    });
+    }));
 
-    assert!(result.is_err(), "Pool total overflow should reject the second bet");
+    assert!(
+        result.is_err(),
+        "Pool total overflow should reject the second bet"
+    );
 }
 
 #[test]
@@ -753,7 +757,6 @@ fn setup() -> TestEnv<'static> {
 
     // Leak env lifetime — acceptable in tests where we own everything
     let client: PredinexContractClient<'static> = unsafe { core::mem::transmute(client) };
-    let env: Env = unsafe { core::mem::transmute(env) };
 
     TestEnv {
         env,
@@ -2760,4 +2763,89 @@ fn l5_claim_winnings_emits_claim_event() {
 
     let expected_fee = (500i128 * 2) / 100;
     assert_eq!(claim_event.fee_amount, expected_fee);
+}
+
+/// #195 — Per-pool protocol revenue matches settlement fee and sums to treasury.
+#[test]
+fn issue195_per_pool_treasury_credited_sums_to_aggregate_before_withdraw() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PredinexContract, ());
+    let client = PredinexContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id.address());
+
+    client.initialize(&token_id.address(), &token_admin);
+
+    let creator = Address::generate(&env);
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+    let u3 = Address::generate(&env);
+    let u4 = Address::generate(&env);
+
+    token_admin_client.mint(&u1, &10_000);
+    token_admin_client.mint(&u2, &10_000);
+    token_admin_client.mint(&u3, &10_000);
+    token_admin_client.mint(&u4, &10_000);
+
+    let expiry_ts = 10_000u64;
+
+    let pool1 = client.create_pool(
+        &creator,
+        &String::from_str(&env, "M1"),
+        &String::from_str(&env, "D"),
+        &String::from_str(&env, "Y"),
+        &String::from_str(&env, "N"),
+        &3600,
+    );
+    let pool2 = client.create_pool(
+        &creator,
+        &String::from_str(&env, "M2"),
+        &String::from_str(&env, "D"),
+        &String::from_str(&env, "Y"),
+        &String::from_str(&env, "N"),
+        &3600,
+    );
+
+    client.place_bet(&u1, &pool1, &0, &300);
+    client.place_bet(&u2, &pool1, &1, &200);
+    client.place_bet(&u3, &pool2, &0, &100);
+    client.place_bet(&u4, &pool2, &1, &100);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = expiry_ts;
+    });
+
+    client.settle_pool(&creator, &pool1, &0);
+    client.settle_pool(&creator, &pool2, &0);
+
+    let fee_bps = client.get_protocol_fee() as i128;
+    let vol1 = 500i128;
+    let vol2 = 200i128;
+    let fee1 = (vol1 * fee_bps) / 10000;
+    let fee2 = (vol2 * fee_bps) / 10000;
+
+    let r1_after_settle = client.get_pool_protocol_revenue(&pool1);
+    let r2_after_settle = client.get_pool_protocol_revenue(&pool2);
+    assert_eq!(r1_after_settle.settlement_protocol_fee, fee1);
+    assert_eq!(r2_after_settle.settlement_protocol_fee, fee2);
+    assert_eq!(r1_after_settle.treasury_credited, 0);
+    assert_eq!(r2_after_settle.treasury_credited, 0);
+
+    client.claim_winnings(&u1, &pool1);
+    client.claim_winnings(&u3, &pool2);
+
+    let r1 = client.get_pool_protocol_revenue(&pool1);
+    let r2 = client.get_pool_protocol_revenue(&pool2);
+    assert_eq!(r1.settlement_protocol_fee, fee1);
+    assert_eq!(r2.settlement_protocol_fee, fee2);
+    assert_eq!(r1.treasury_credited, fee1);
+    assert_eq!(r2.treasury_credited, fee2);
+
+    let treasury = client.get_treasury_balance();
+    assert_eq!(treasury, r1.treasury_credited + r2.treasury_credited);
+    assert_eq!(treasury, fee1 + fee2);
 }


### PR DESCRIPTION
…195)

Record each settled market's floor(bps) protocol fee at settlement and accumulate per-pool treasury credits in lockstep with aggregate Treasury (fee on first winner claim, payout dust on final claim).

#195 
Add get_pool_protocol_revenue for analytics and reconcile sum(pool credits) with get_treasury_balance before withdrawals.

Repair claim_winnings: persist PoolPayoutState, credit treasury once per fee+dust cycle, and restore missing contract types (PoolPayoutState, ClaimEvent, DataKey variants).

Harden create_pool with documented duration bounds, non-empty string validation, and preview_claimable_amount using get_protocol_fee.
closes #195 
Tests: issue195 sum reconciliation; AssertUnwindSafe for overflow test; remove useless Env transmutes for clippy --tests.

Made-with: #195 