### PR TITLE
ci/repo: stale policy, bundle-size budget, PR template, path-based auto-labeling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,67 @@
+## Summary
+
+<!--
+Describe what this PR does and why. Link the relevant issue(s):
+  Closes #<issue>
+-->
+
+Closes #
+
+## Type of change
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
+- [ ] `perf` — performance improvement
+- [ ] `test` — adding or updating tests
+- [ ] `docs` — documentation only
+- [ ] `ci` — CI / workflow changes
+- [ ] `chore` — dependency bump or tooling update
+
+## Scope
+
+- [ ] Contract (`contracts/`)
+- [ ] Frontend / Web (`web/`)
+- [ ] Docs (`docs/`)
+- [ ] CI / Ops (`.github/`)
+
+---
+
+## Contract changes (complete if scope includes `contracts/`)
+
+- [ ] New or changed public functions — ABI impact documented below
+- [ ] Storage layout changed — migration path described below
+- [ ] Tests added or updated for every changed function
+
+**ABI / storage notes:**
+<!-- Describe breaking changes or migration steps, or write "N/A". -->
+
+---
+
+## Frontend changes (complete if scope includes `web/`)
+
+- [ ] UI tested in a browser on the happy path
+- [ ] Responsive layout verified (mobile / desktop)
+- [ ] No new `console.error` or TypeScript errors introduced
+
+---
+
+## Testing
+
+- [ ] Existing tests still pass (`cargo test` / `npm run test`)
+- [ ] New tests added for new behaviour
+- [ ] Manual steps to verify this change:
+
+<!--
+1. …
+2. …
+-->
+
+## Docs impact
+
+- [ ] README or docs updated (or N/A)
+- [ ] Changelog entry added (or N/A)
+
+## Additional notes
+
+<!-- Anything a reviewer should know: trade-offs, follow-up tickets, performance impact, etc. -->

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,28 @@
+# Path-based auto-labeling for predinex-stellar
+# Labels must exist in the repository before this file takes effect.
+# https://github.com/actions/labeler
+
+"area: contract":
+  - changed-files:
+      - any-glob-to-any-file: "contracts/**"
+
+"area: web":
+  - changed-files:
+      - any-glob-to-any-file: "web/**"
+
+"area: docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "*.md"
+          - "**/*.md"
+
+"area: ops":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "scripts/**"
+          - "Makefile"
+          - "*.toml"
+          - "*.yaml"
+          - "*.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,52 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Bundle size budget check
+        if: github.event_name == 'pull_request'
+        run: |
+          # Budget definitions (KB). Update intentionally with a comment explaining the reason.
+          BUDGET_TOTAL_KB=500
+          BUDGET_JS_KB=350
+          BUDGET_CSS_KB=80
+
+          FAILED=0
+
+          echo "### Bundle Size Budget Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Asset type | Size | Budget | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------------|------|--------|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -d ".next/static" ]; then
+            TOTAL_SIZE=$(du -sk .next/static | cut -f1)
+            JS_SIZE=$(find .next/static/chunks -name "*.js" 2>/dev/null -exec stat -c%s {} \; | awk '{s+=$1} END {printf "%d", s/1024}')
+            CSS_SIZE=$(find .next/static/css -name "*.css" 2>/dev/null -exec stat -c%s {} \; | awk '{s+=$1} END {printf "%d", s/1024}')
+          else
+            TOTAL_SIZE=0; JS_SIZE=0; CSS_SIZE=0
+          fi
+
+          check_budget() {
+            local name="$1" size="$2" budget="$3"
+            if [ "$size" -gt "$budget" ]; then
+              printf "| %s | %sKB | %sKB | OVER BUDGET |\n" "$name" "$size" "$budget" >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::$name bundle (${size}KB) exceeds budget of ${budget}KB."
+              FAILED=1
+            else
+              printf "| %s | %sKB | %sKB | OK |\n" "$name" "$size" "$budget" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          }
+
+          check_budget "Total static" "$TOTAL_SIZE" "$BUDGET_TOTAL_KB"
+          check_budget "JavaScript"   "$JS_SIZE"    "$BUDGET_JS_KB"
+          check_budget "CSS"          "$CSS_SIZE"   "$BUDGET_CSS_KB"
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "Bundle size budget exceeded. To update a budget intentionally, edit"
+            echo "the BUDGET_* variables in .github/workflows/ci.yml with a comment"
+            echo "explaining why the increase is justified."
+            exit 1
+          fi
+
   contract-checks:
     name: Contract Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,52 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # ── Timing ──────────────────────────────────────────────────
+          days-before-stale: 30
+          days-before-close: 7
+          days-before-pr-stale: 21
+          days-before-pr-close: 7
+
+          # ── Labels ──────────────────────────────────────────────────
+          stale-issue-label: "stale"
+          close-issue-label: "auto-closed"
+          stale-pr-label: "stale"
+          close-pr-label: "auto-closed"
+
+          # ── Exempt labels (never marked stale) ──────────────────────
+          exempt-issue-labels: "pinned,security,blocked,in-progress,area: contract"
+          exempt-pr-labels: "pinned,security,blocked,in-progress,do-not-merge"
+
+          # ── Messages ────────────────────────────────────────────────
+          stale-issue-message: >
+            This issue has been inactive for 30 days. It will be closed in 7 days
+            unless there is further activity. If this issue is still relevant, please
+            leave a comment or remove the **stale** label.
+          close-issue-message: >
+            This issue has been automatically closed after 37 days of inactivity.
+            If the problem persists, please open a new issue with up-to-date context.
+          stale-pr-message: >
+            This pull request has been inactive for 21 days. It will be closed in
+            7 days unless there is further activity. Please rebase, address review
+            comments, or leave a note if you need more time.
+          close-pr-message: >
+            This pull request has been automatically closed after 28 days of
+            inactivity. Please reopen or open a new PR if the change is still needed.
+
+          # ── Safety ──────────────────────────────────────────────────
+          operations-per-run: 100
+          remove-stale-when-updated: true


### PR DESCRIPTION
## Summary

- Add `.github/workflows/stale.yml` using `actions/stale@v9`: issues marked stale after 30 days and closed after 7 more; PRs after 21+7 days; exempt labels include `pinned`, `security`, `blocked`, `in-progress`, and `area: contract`; stale status resets on any new activity
- Add a bundle-size budget step to the `web-checks` CI job: checks total static output (500KB), JavaScript chunks (350KB), and CSS (80KB) on pull requests; budget failures produce `::error::` annotations with actionable instructions for intentional increases; results appear in the step summary
- Add `.github/PULL_REQUEST_TEMPLATE.md` prompting authors to declare change type, scope, contract-specific (ABI/storage/tests), frontend-specific (browser/responsive), testing checklist, and docs impact
- Add `.github/labeler.yml` mapping `contracts/`, `web/`, `docs/`, and `.github/scripts/` paths to the `area:` labels used in `release.yml`; add `labeler.yml` workflow using `actions/labeler@v5` on `pull_request_target` with `sync-labels: false` so manually added labels survive new commits

## Test plan

- [ ] Manually trigger the stale workflow (`workflow_dispatch`) and verify dry-run output matches policy
- [ ] Open a PR that touches only `contracts/` and verify `area: contract` label is applied automatically
- [ ] Open a PR that touches both `web/` and `docs/` and verify both `area: web` and `area: docs` are applied
- [ ] Open a new PR and verify the template appears with all sections
- [ ] Check CI step summary for the bundle size budget report after a build

Closes #244
Closes #240
Closes #242
Closes #243