### PR TITLE
feat: add route smoke tests for all App Router pages and contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,242 @@
+# Contributing to Predinex Stellar
+
+Welcome, and thank you for your interest in contributing! This guide covers everything you need to go from a clean checkout to an open pull request: local setup, running checks, documentation standards, and the issue workflow.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Local Setup](#2-local-setup)
+3. [Running Web Checks](#3-running-web-checks)
+4. [Running Contract Checks](#4-running-contract-checks)
+5. [Documentation Standards](#5-documentation-standards)
+6. [Issue and PR Workflow](#6-issue-and-pr-workflow)
+7. [CI Expectations](#7-ci-expectations)
+
+---
+
+## 1. Prerequisites
+
+| Tool | Minimum version | Notes |
+|------|----------------|-------|
+| Node.js | 18 | 22 is used in CI |
+| npm | 8 | **Do not use pnpm or yarn** — it creates lockfile conflicts |
+| Rust + Cargo | stable (1.74+) | Install via [rustup.rs](https://rustup.rs) |
+| `wasm32-unknown-unknown` | — | `rustup target add wasm32-unknown-unknown` |
+| Stellar CLI | 21+ | [Installation guide](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup) |
+| Freighter wallet | latest | [freighter.app](https://www.freighter.app) — browser extension for UI testing |
+
+Run the bootstrap script to verify everything is installed:
+
+```bash
+./scripts/bootstrap.sh
+```
+
+---
+
+## 2. Local Setup
+
+### Clone and install
+
+```bash
+git clone <repository-url>
+cd predinex-stellar
+
+# Install web dependencies
+cd web
+npm install
+cd ..
+```
+
+### Environment variables
+
+Create `web/.env.local` with:
+
+```env
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_NETWORK=testnet
+NEXT_PUBLIC_SOROBAN_CONTRACT_ID=<testnet-contract-C-strkey>
+```
+
+The contract address for the shared testnet deployment is in `web/.env.example`. For a local deployment, follow the [Local End-to-End Runbook](./docs/local-runbook.md).
+
+### Start the development server
+
+```bash
+cd web
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+---
+
+## 3. Running Web Checks
+
+All three checks must pass before opening a PR. Run them from the `web/` directory:
+
+```bash
+# Lint
+npm run lint
+
+# Unit tests (single run, matches CI)
+npm test -- --run
+
+# Production build
+npm run build
+```
+
+### Test suite
+
+Tests live in `web/tests/` and use [Vitest](https://vitest.dev/) with React Testing Library.
+
+| Directory | What it covers |
+|-----------|---------------|
+| `tests/components/` | React component behaviour |
+| `tests/routes/` | Route-level smoke tests — verifies every top-level App Router page mounts without crashing |
+| `tests/lib/` | API client and utility functions |
+| `tests/helpers/` | Shared render helpers (`renderWithProviders`) |
+| `tests/integration/` | Cross-cutting integration scenarios |
+
+Run a single file during development:
+
+```bash
+npm test -- --run tests/routes/smoke.test.tsx
+```
+
+Run in watch mode while iterating:
+
+```bash
+npm test -- --watch
+```
+
+Run with coverage:
+
+```bash
+npm run test:coverage
+```
+
+**When adding a new top-level route**, add a smoke test entry to `tests/routes/smoke.test.tsx` so CI catches broken imports or missing providers at the route level.
+
+---
+
+## 4. Running Contract Checks
+
+Run these from `contracts/predinex/`:
+
+```bash
+# Format check
+cargo fmt --check
+
+# Lint
+cargo clippy -- -D warnings
+
+# Unit tests
+cargo test
+```
+
+To build the WASM artifact:
+
+```bash
+stellar contract build
+```
+
+The compiled output lands at `contracts/predinex/target/wasm32-unknown-unknown/release/predinex.wasm`.
+
+For a full local deploy-to-testnet walkthrough, see the [Local End-to-End Runbook](./docs/local-runbook.md).
+
+---
+
+## 5. Documentation Standards
+
+### Code comments
+
+Only add a comment when the **why** is non-obvious — a hidden constraint, a subtle invariant, or a workaround for a specific bug. Do not comment on what the code does; well-named identifiers already do that.
+
+### JSDoc
+
+Add JSDoc to exported utility functions and complex hooks. One short summary line is enough; avoid multi-paragraph blocks.
+
+### Architecture docs
+
+Significant architectural decisions (new caching strategies, contract interface changes, new hooks) belong in `web/docs/`. Reference them from `web/DEVELOPMENT.md` or `web/FRONTEND.md` as appropriate.
+
+### Contract interface changes
+
+Any change that touches the contract interface must follow the process in [docs/CONTRACT_VERSIONING.md](./web/docs/CONTRACT_VERSIONING.md). Breaking changes require an explicit major version bump and a migration note before the PR can be merged.
+
+---
+
+## 6. Issue and PR Workflow
+
+### Picking up an issue
+
+1. Comment on the issue to let others know you are working on it.
+2. Fork the repository and clone your fork.
+3. Create a branch from `main` using the convention below.
+
+### Branch naming
+
+```
+<type>/<short-description>
+```
+
+Examples:
+
+- `feat/route-smoke-tests`
+- `fix/market-pagination-reset`
+- `docs/contributing-guide`
+- `refactor/wallet-adapter-cleanup`
+
+### Commit messages
+
+Write imperative-mood subject lines under 72 characters. Put context in the body when needed.
+
+```
+feat: add smoke tests for all top-level App Router routes
+
+Covers home, markets, create, dashboard, disputes, rewards,
+activity, and incentives. Uses a shared provider harness so
+route-level provider failures are caught independently of the
+component suite.
+```
+
+### Pull request checklist
+
+Before marking a PR ready for review:
+
+- [ ] `npm run lint` passes
+- [ ] `npm test -- --run` passes (no new failures)
+- [ ] `npm run build` succeeds
+- [ ] Contract checks pass if contract files were touched (`cargo fmt --check`, `cargo clippy`, `cargo test`)
+- [ ] PR description references the issue number(s) with `Closes #<number>`
+- [ ] New top-level routes include a smoke test entry in `tests/routes/smoke.test.tsx`
+- [ ] New architectural decisions are documented in `web/docs/`
+
+### PR description template
+
+The repository provides a pull request template at `.github/PULL_REQUEST_TEMPLATE.md`. Fill it in completely — incomplete descriptions slow down review.
+
+---
+
+## 7. CI Expectations
+
+The CI workflow (`.github/workflows/ci.yml`) runs on every push and pull request to `main`. It includes:
+
+| Job | Steps |
+|-----|-------|
+| **Web Checks** | `npm ci` → `npm run lint` → `npm test -- --run` → `npm run build` |
+| **Bundle size budget** | Checked on PRs; fails if JS exceeds 350 KB, CSS exceeds 80 KB, or total static exceeds 500 KB |
+| **Contract Checks** | `cargo fmt --check` → `cargo clippy -- -D warnings` → `cargo test` |
+
+Run all of these locally before pushing to avoid CI failures blocking your PR.
+
+---
+
+For deeper context on the project architecture, see:
+
+- [Frontend Development Guide](./web/DEVELOPMENT.md)
+- [Frontend Architecture](./web/FRONTEND.md)
+- [Local End-to-End Runbook](./docs/local-runbook.md)
+- [Release Process](./RELEASE.md)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ Predinex Stellar follows a phased approach to bring a premium betting experience
 
 ## 🤝 Contributing & Releases
 
-We welcome contributions! Please see our development guides for more information:
+We welcome contributions! Please read the [Contributing Guide](./CONTRIBUTING.md) first — it covers local setup, running checks, documentation standards, and the issue/PR workflow.
+
+Additional development guides:
 - [Local End-to-End Runbook](./docs/local-runbook.md) — build the contract, deploy to testnet, and wire the web app from a clean checkout
 - [Frontend Development](./web/DEVELOPMENT.md)
 - [Release Process](./RELEASE.md)

--- a/web/tests/README.md
+++ b/web/tests/README.md
@@ -6,7 +6,9 @@ This directory contains tests for the Next.js web frontend application.
 
 - `setup.ts` - Test environment configuration and mocks
 - `components/` - React component tests
+- `routes/` - Route-level smoke tests (verifies each top-level App Router page mounts without crashing)
 - `lib/` - API client and utility function tests
+- `helpers/` - Shared render utilities (`renderWithProviders`)
 
 ## Running Tests
 

--- a/web/tests/routes/smoke.test.tsx
+++ b/web/tests/routes/smoke.test.tsx
@@ -1,0 +1,303 @@
+/**
+ * Route smoke tests — verify every top-level App Router page mounts without
+ * crashing.  These tests catch broken imports, missing providers, and
+ * route-only regressions that component-focused suites won't see.
+ *
+ * Each test renders the page inside the shared provider tree and asserts that
+ * the route's landmark element (main) is present in the document.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../helpers/renderWithProviders';
+
+// ── Shared infrastructure mocks ───────────────────────────────────────────────
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('next/dynamic', () => ({
+  default: (loader: () => Promise<{ default: React.ComponentType }>) => {
+    const LazyComponent = React.lazy(loader);
+    return function DynamicComponent(props: Record<string, unknown>) {
+      return (
+        <React.Suspense fallback={null}>
+          <LazyComponent {...props} />
+        </React.Suspense>
+      );
+    };
+  },
+}));
+
+// ── Wallet / auth mocks ───────────────────────────────────────────────────────
+
+const mockWallet = {
+  chain: 'stacks' as const,
+  isConnected: false,
+  isLoading: false,
+  address: null,
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+};
+
+vi.mock('../../app/components/WalletAdapterProvider', () => ({
+  useWallet: vi.fn(() => mockWallet),
+  WalletAdapterProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../app/components/StacksProvider', () => ({
+  useStacks: vi.fn(() => ({
+    userData: null,
+    authenticate: vi.fn(),
+    userSession: {},
+    setUserData: vi.fn(),
+    signOut: vi.fn(),
+    openWalletModal: vi.fn(),
+    isLoading: false,
+  })),
+  StacksProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../app/lib/hooks/useWalletConnect', () => ({
+  useWalletConnect: vi.fn(() => ({ session: null })),
+}));
+
+// ── UI / layout mocks ─────────────────────────────────────────────────────────
+
+vi.mock('../../app/components/Navbar', () => ({
+  default: () => <nav data-testid="navbar" />,
+}));
+
+vi.mock('../../app/components/AuthGuard', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../components/RouteErrorBoundary', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// ── Data / hook mocks ─────────────────────────────────────────────────────────
+
+vi.mock('../../app/lib/hooks/useMarketDiscovery', () => ({
+  useMarketDiscovery: vi.fn(() => ({
+    paginatedMarkets: [],
+    isLoading: false,
+    error: null,
+    blockHeightWarning: null,
+    filters: { search: '', status: 'all', sortBy: 'newest' },
+    pagination: { page: 1, totalPages: 1, total: 0, pageSize: 12 },
+    setSearch: vi.fn(),
+    setStatusFilter: vi.fn(),
+    setSortBy: vi.fn(),
+    setPage: vi.fn(),
+    retry: vi.fn(),
+    filteredMarkets: [],
+  })),
+}));
+
+vi.mock('../../app/lib/hooks/useLeaderboard', () => ({
+  useLeaderboard: vi.fn(() => ({ userRank: null, entries: [] })),
+}));
+
+vi.mock('../../app/hooks/useUserActivity', () => ({
+  useUserActivity: vi.fn(() => ({
+    activities: [],
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+  })),
+}));
+
+vi.mock('../../app/lib/hooks/useActiveBets', () => ({
+  useActiveBets: vi.fn(() => ({
+    activeBets: [],
+    isLoading: false,
+    refresh: vi.fn(),
+  })),
+}));
+
+vi.mock('../../app/lib/hooks/useWalletConnect', () => ({
+  useWalletConnect: vi.fn(() => ({ session: null })),
+}));
+
+// ── Component mocks (heavy/async dependencies) ────────────────────────────────
+
+vi.mock('../../app/components/Hero', () => ({
+  default: () => <section data-testid="hero" />,
+}));
+
+vi.mock('../../app/components/IncentivesDisplay', () => ({
+  default: () => <div data-testid="incentives-display" />,
+}));
+
+vi.mock('../../app/components/DisputeManagement', () => ({
+  default: () => <div data-testid="dispute-management" />,
+}));
+
+vi.mock('../../app/components/SearchBar', () => ({
+  default: () => <input data-testid="search-bar" />,
+}));
+
+vi.mock('../../app/components/FilterControls', () => ({
+  default: () => <div data-testid="filter-controls" />,
+}));
+
+vi.mock('../../app/components/SortControls', () => ({
+  default: () => <div data-testid="sort-controls" />,
+}));
+
+vi.mock('../../app/components/MarketGrid', () => ({
+  default: () => <div data-testid="market-grid" />,
+}));
+
+vi.mock('../../app/components/Pagination', () => ({
+  default: () => <div data-testid="pagination" />,
+}));
+
+vi.mock('../../app/components/ActivityFeed', () => ({
+  default: () => <div data-testid="activity-feed" />,
+}));
+
+vi.mock('../../components/Leaderboard', () => ({
+  default: () => <div data-testid="leaderboard" />,
+}));
+
+vi.mock('../../components/PlatformStats', () => ({
+  default: () => <div data-testid="platform-stats" />,
+}));
+
+vi.mock('../../components/PortfolioOverview', () => ({
+  default: () => <div data-testid="portfolio-overview" />,
+}));
+
+vi.mock('../../components/EmptyState', () => ({
+  default: ({ message }: { message: string }) => <p>{message}</p>,
+}));
+
+vi.mock('../../components/DisconnectedState', () => ({
+  default: () => <div data-testid="disconnected-state" />,
+}));
+
+vi.mock('../../app/components/dashboard/ActiveBetsCard', () => ({
+  default: () => <div data-testid="active-bets-card" />,
+}));
+
+vi.mock('../../components/ui/StatsCard', () => ({
+  StatsCard: ({ title, value }: { title: string; value: unknown }) => (
+    <div data-testid="stats-card">{title}: {String(value)}</div>
+  ),
+}));
+
+vi.mock('../../components/ui/MarketCardHeader', () => ({
+  default: () => <div data-testid="market-card-header" />,
+}));
+
+vi.mock('../../components/ui/accordion', () => ({
+  Accordion: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AccordionItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AccordionTrigger: ({ children }: { children: React.ReactNode }) => <button type="button">{children}</button>,
+  AccordionContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../app/lib/runtime-config', () => ({
+  getRuntimeConfig: vi.fn(() => ({
+    network: 'testnet',
+    contract: {
+      address: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
+      name: 'predinex-pool',
+      id: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.predinex-pool',
+    },
+    api: { coreApiUrl: '', explorerUrl: '', rpcUrl: '' },
+  })),
+}));
+
+vi.mock('@stacks/connect', () => ({
+  openContractCall: vi.fn(),
+  AppConfig: vi.fn(),
+  UserSession: vi.fn(() => ({
+    isSignInPending: () => false,
+    isUserSignedIn: () => false,
+    handlePendingSignIn: vi.fn(),
+    loadUserData: vi.fn(),
+    signUserOut: vi.fn(),
+  })),
+  showConnect: vi.fn(),
+}));
+
+// ── Route imports ─────────────────────────────────────────────────────────────
+
+import HomePage from '../../app/page';
+import MarketsPage from '../../app/markets/page';
+import CreatePage from '../../app/create/page';
+import DashboardPage from '../../app/dashboard/page';
+import DisputesPage from '../../app/disputes/page';
+import RewardsPage from '../../app/rewards/page';
+import ActivityPage from '../../app/activity/page';
+import IncentivesPage from '../../app/incentives/page';
+
+// ── Smoke suite ───────────────────────────────────────────────────────────────
+
+import * as WalletAdapterProvider from '../../app/components/WalletAdapterProvider';
+
+const connectedWallet = {
+  chain: 'stacks' as const,
+  isConnected: true,
+  isLoading: false,
+  address: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+};
+
+describe('Route smoke tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default to disconnected wallet; individual tests override as needed.
+    vi.mocked(WalletAdapterProvider.useWallet).mockReturnValue(mockWallet);
+  });
+
+  it('home (/) renders without crashing', () => {
+    renderWithProviders(<HomePage />);
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('/markets renders without crashing', () => {
+    renderWithProviders(<MarketsPage />);
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('/create renders without crashing', () => {
+    renderWithProviders(<CreatePage />);
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('/dashboard renders without crashing', () => {
+    // Dashboard shows the full layout only when a wallet is connected.
+    vi.mocked(WalletAdapterProvider.useWallet).mockReturnValue(connectedWallet);
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('/disputes renders without crashing', () => {
+    renderWithProviders(<DisputesPage />);
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('/rewards renders without crashing', () => {
+    renderWithProviders(<RewardsPage />);
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('/activity renders without crashing', () => {
+    renderWithProviders(<ActivityPage />);
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('/incentives renders without crashing', () => {
+    renderWithProviders(<IncentivesPage />);
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- **Testing (#229):** Adds `web/tests/routes/smoke.test.tsx` — a shared-provider smoke harness that renders all eight top-level App Router pages (`/`, `/markets`, `/create`, `/dashboard`, `/disputes`, `/rewards`, `/activity`, `/incentives`) and asserts each mounts without crashing. Catches broken imports, missing providers, and route-only regressions that component-focused suites miss.
- **Docs (#241):** Adds `CONTRIBUTING.md` — a single contributor-oriented guide covering local setup, web and contract checks, documentation standards, and the issue/PR workflow. Updates `README.md` to link to it.

## Changes

### `web/tests/routes/smoke.test.tsx` (new)
- Shared mock infrastructure for wallet/auth providers, Next.js navigation, `next/dynamic`, and heavy child components keeps the suite fast and CI-reliable.
- Dashboard smoke test explicitly sets a connected wallet state because the page renders `<DisconnectedState />` (no `<main>`) when the wallet is absent — this documents intentional behaviour.
- All 8 tests pass; pre-existing test failures in other files are unrelated.

### `CONTRIBUTING.md` (new)
- Prerequisites table with exact versions matching CI (`node-version: 22`, `rustup stable`)
- Local setup: clone → env vars → dev server
- Web checks section with single-file and watch-mode examples
- Contract checks section (`cargo fmt --check`, `cargo clippy`, `cargo test`, `stellar contract build`)
- Documentation standards (comment philosophy, JSDoc, architecture docs, contract versioning)
- Issue/PR workflow (branch naming convention, commit format, PR checklist)
- CI expectations table derived from `.github/workflows/ci.yml`

### `README.md`
- Contributing section now links to `CONTRIBUTING.md` as the primary entry point.

### `web/tests/README.md`
- Documents the new `routes/` directory and the existing `helpers/` directory.

## Test plan

- [x] `npm test -- --run tests/routes/smoke.test.tsx` — 8/8 pass
- [x] Confirmed the guide's documented commands match the active CI workflow (`.github/workflows/ci.yml`)
- [x] Confirmed README link resolves to the new `CONTRIBUTING.md`

Closes #229
Closes #241