### PR TITLE
Contract: add multi-user accumulation and fuzz tests (#182, #188)

### DIFF
--- a/contracts/predinex/src/fuzz_tests.rs
+++ b/contracts/predinex/src/fuzz_tests.rs
@@ -1,0 +1,631 @@
+// ============================================================================
+// Issue #182: Fuzz / property tests for uneven winner and loser distributions
+//
+// These tests generate diverse bet distributions across both outcomes and
+// verify that payout totals and fee accounting are correct for every case.
+// A deterministic pseudo-random generator is used so the suite is stable
+// for CI and fully reproducible without an external fuzzing harness.
+//
+// Running mode:
+//   cargo test --package predinex -- fuzz_tests   (single-pass, CI-safe)
+//
+// Each test either:
+//   (a) iterates over a hand-crafted set of representative distributions, or
+//   (b) uses a deterministic LCG to generate N random distributions and
+//       verifies the invariants hold for every generated case.
+// ============================================================================
+
+#![cfg(test)]
+extern crate std;
+use super::*;
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, String};
+
+// ── Deterministic pseudo-random number generator ─────────────────────────────
+//
+// A simple 64-bit LCG (Knuth multiplicative) that is fully deterministic and
+// requires no external crates. Sufficient for generating diverse distributions
+// in a reproducible way.
+
+struct Lcg(u64);
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Lcg(seed)
+    }
+
+    /// Return the next pseudo-random u64.
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.0
+    }
+
+    /// Return a value in [1, max] (inclusive).
+    fn next_in(&mut self, max: u64) -> u64 {
+        (self.next() % max) + 1
+    }
+}
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+struct FuzzEnv<'a> {
+    env: Env,
+    client: PredinexContractClient<'a>,
+    token: Address,
+    contract_id: Address,
+}
+
+fn setup_fuzz() -> FuzzEnv<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+
+    let contract_id = env.register(PredinexContract, ());
+    let client = PredinexContractClient::new(&env, &contract_id);
+
+    client.initialize(&token_id.address(), &token_admin);
+
+    let client: PredinexContractClient<'static> = unsafe { core::mem::transmute(client) };
+
+    FuzzEnv {
+        env,
+        client,
+        token: token_id.address(),
+        contract_id,
+    }
+}
+
+fn mint_fuzz(env: &Env, token: &Address, user: &Address, amount: i128) {
+    let admin = soroban_sdk::token::StellarAssetClient::new(env, token);
+    admin.mint(user, &amount);
+}
+
+fn make_pool_fuzz(t: &FuzzEnv) -> (u32, Address) {
+    let creator = Address::generate(&t.env);
+    let pool_id = t.client.create_pool(
+        &creator,
+        &String::from_str(&t.env, "Fuzz Pool"),
+        &String::from_str(&t.env, "Property test pool"),
+        &String::from_str(&t.env, "Yes"),
+        &String::from_str(&t.env, "No"),
+        &3_600u64,
+    );
+    (pool_id, creator)
+}
+
+fn expire_fuzz(env: &Env) {
+    env.ledger().with_mut(|li| {
+        li.timestamp = 7_200;
+    });
+}
+
+// ── Invariant helpers ─────────────────────────────────────────────────────────
+
+/// Verify the core payout invariant for a single winner in a two-outcome pool:
+///
+///   winnings = floor(user_winning_bet * net_pool / winning_side_total)
+///   net_pool = total_pool - floor(total_pool * fee_bps / 10_000)
+///
+/// Returns the computed winnings so callers can cross-check against the
+/// actual transfer.
+fn expected_winnings(
+    user_winning_bet: i128,
+    winning_side_total: i128,
+    total_pool: i128,
+    fee_bps: i128,
+) -> i128 {
+    let fee = (total_pool * fee_bps) / 10_000;
+    let net = total_pool - fee;
+    (user_winning_bet * net) / winning_side_total
+}
+
+// ── Suite P — property / fuzz tests ──────────────────────────────────────────
+
+/// P1: Payout formula holds for a hand-crafted set of uneven distributions.
+///
+/// Each entry is (total_a, total_b, winning_outcome). A single winner holds
+/// the entire winning side so the payout must equal the full net pool.
+#[test]
+fn p1_payout_formula_holds_for_uneven_distributions() {
+    // (total_a, total_b, winning_outcome)
+    let cases: &[(i128, i128, u32)] = &[
+        (1, 999, 0),    // tiny winning side
+        (999, 1, 1),    // tiny losing side
+        (500, 500, 0),  // equal sides, A wins
+        (500, 500, 1),  // equal sides, B wins
+        (1, 1, 0),      // minimal pool
+        (10_000, 1, 0), // heavily skewed toward A
+        (1, 10_000, 1), // heavily skewed toward B
+        (333, 667, 0),  // non-round split, A wins
+        (667, 333, 1),  // non-round split, B wins
+        (100, 900, 0),  // 10/90 split, A wins
+        (900, 100, 1),  // 90/10 split, B wins
+    ];
+
+    for &(total_a, total_b, winning_outcome) in cases {
+        let t = setup_fuzz();
+        let (pool_id, creator) = make_pool_fuzz(&t);
+
+        let winner = Address::generate(&t.env);
+        let loser = Address::generate(&t.env);
+
+        mint_fuzz(&t.env, &t.token, &winner, total_a.max(total_b) + 1);
+        mint_fuzz(&t.env, &t.token, &loser, total_a.max(total_b) + 1);
+
+        if winning_outcome == 0 {
+            t.client.place_bet(&winner, &pool_id, &0u32, &total_a);
+            if total_b > 0 {
+                t.client.place_bet(&loser, &pool_id, &1u32, &total_b);
+            }
+        } else {
+            if total_a > 0 {
+                t.client.place_bet(&loser, &pool_id, &0u32, &total_a);
+            }
+            t.client.place_bet(&winner, &pool_id, &1u32, &total_b);
+        }
+
+        expire_fuzz(&t.env);
+        t.client.settle_pool(&creator, &pool_id, &winning_outcome);
+
+        let total_pool = total_a + total_b;
+        let winning_side_total = if winning_outcome == 0 { total_a } else { total_b };
+        let expected =
+            expected_winnings(winning_side_total, winning_side_total, total_pool, 200);
+
+        let actual = t.client.claim_winnings(&winner, &pool_id);
+        assert_eq!(
+            actual, expected,
+            "payout mismatch for case total_a={total_a} total_b={total_b} outcome={winning_outcome}"
+        );
+    }
+}
+
+/// P2: Fee accounting is correct for diverse pool sizes.
+///
+/// For each case the treasury must hold exactly floor(total_pool * 2 / 100)
+/// after the sole winner claims.
+#[test]
+fn p2_fee_accounting_correct_for_diverse_pool_sizes() {
+    let pool_sizes: &[(i128, i128)] = &[
+        (100, 100),
+        (1, 1),
+        (999, 1),
+        (1, 999),
+        (50_000, 50_000),
+        (123, 456),
+        (789, 321),
+        (1_000_000, 1),
+        (1, 1_000_000),
+    ];
+
+    for &(total_a, total_b) in pool_sizes {
+        let t = setup_fuzz();
+        let (pool_id, creator) = make_pool_fuzz(&t);
+
+        let winner = Address::generate(&t.env);
+        let loser = Address::generate(&t.env);
+
+        mint_fuzz(&t.env, &t.token, &winner, total_a + 1);
+        mint_fuzz(&t.env, &t.token, &loser, total_b + 1);
+
+        t.client.place_bet(&winner, &pool_id, &0u32, &total_a);
+        t.client.place_bet(&loser, &pool_id, &1u32, &total_b);
+
+        expire_fuzz(&t.env);
+        t.client.settle_pool(&creator, &pool_id, &0u32);
+
+        t.client.claim_winnings(&winner, &pool_id);
+
+        let total_pool = total_a + total_b;
+        let expected_fee = (total_pool * 200) / 10_000;
+
+        let treasury = t.client.get_treasury_balance();
+        // Treasury must hold at least the fee (dust may add a small amount)
+        assert!(
+            treasury >= expected_fee,
+            "treasury must hold at least the fee for pool ({total_a}, {total_b})"
+        );
+        // And must not exceed fee + 1 (single-winner pool has at most 1 dust token)
+        assert!(
+            treasury <= expected_fee + 1,
+            "treasury must not exceed fee + 1 dust for pool ({total_a}, {total_b})"
+        );
+    }
+}
+
+/// P3: Deterministic fuzz — 50 randomly generated single-winner distributions.
+///
+/// Uses a seeded LCG to generate (total_a, total_b) pairs and verifies the
+/// payout formula and fee invariant for each.
+#[test]
+fn p3_deterministic_fuzz_single_winner_distributions() {
+    let mut rng = Lcg::new(0xDEAD_BEEF_CAFE_1234);
+
+    for iteration in 0..50u32 {
+        let total_a = rng.next_in(100_000) as i128;
+        let total_b = rng.next_in(100_000) as i128;
+        let winning_outcome: u32 = (rng.next() % 2) as u32;
+
+        let t = setup_fuzz();
+        let (pool_id, creator) = make_pool_fuzz(&t);
+
+        let winner = Address::generate(&t.env);
+        let loser = Address::generate(&t.env);
+
+        mint_fuzz(&t.env, &t.token, &winner, total_a.max(total_b) + 1);
+        mint_fuzz(&t.env, &t.token, &loser, total_a.max(total_b) + 1);
+
+        if winning_outcome == 0 {
+            t.client.place_bet(&winner, &pool_id, &0u32, &total_a);
+            t.client.place_bet(&loser, &pool_id, &1u32, &total_b);
+        } else {
+            t.client.place_bet(&loser, &pool_id, &0u32, &total_a);
+            t.client.place_bet(&winner, &pool_id, &1u32, &total_b);
+        }
+
+        expire_fuzz(&t.env);
+        t.client.settle_pool(&creator, &pool_id, &winning_outcome);
+
+        let total_pool = total_a + total_b;
+        let winning_side_total = if winning_outcome == 0 { total_a } else { total_b };
+        let expected =
+            expected_winnings(winning_side_total, winning_side_total, total_pool, 200);
+
+        let actual = t.client.claim_winnings(&winner, &pool_id);
+        assert_eq!(
+            actual, expected,
+            "fuzz iteration {iteration}: payout mismatch for total_a={total_a} total_b={total_b} outcome={winning_outcome}"
+        );
+
+        let expected_fee = (total_pool * 200) / 10_000;
+        let treasury = t.client.get_treasury_balance();
+        assert!(
+            treasury >= expected_fee,
+            "fuzz iteration {iteration}: treasury below fee for total_a={total_a} total_b={total_b}"
+        );
+        assert!(
+            treasury <= expected_fee + 1,
+            "fuzz iteration {iteration}: treasury exceeds fee+1 for total_a={total_a} total_b={total_b}"
+        );
+    }
+}
+
+/// P4: Deterministic fuzz — 30 multi-winner distributions.
+///
+/// Generates pools with 2–5 winners and 1–3 losers. Verifies that:
+///   - Each winner's payout matches the formula.
+///   - The sum of all payouts plus treasury equals the total pool.
+///   - No loser can claim.
+#[test]
+fn p4_deterministic_fuzz_multi_winner_distributions() {
+    let mut rng = Lcg::new(0x1234_5678_9ABC_DEF0);
+
+    for iteration in 0..30u32 {
+        let num_winners = (rng.next_in(4) + 1) as usize; // 2–5
+        let num_losers = rng.next_in(3) as usize; // 1–3
+
+        let t = setup_fuzz();
+        let (pool_id, creator) = make_pool_fuzz(&t);
+
+        let winners: alloc::vec::Vec<Address> = (0..num_winners)
+            .map(|_| Address::generate(&t.env))
+            .collect();
+        let losers: alloc::vec::Vec<Address> = (0..num_losers)
+            .map(|_| Address::generate(&t.env))
+            .collect();
+
+        let winner_bets: alloc::vec::Vec<i128> = (0..num_winners)
+            .map(|_| rng.next_in(10_000) as i128)
+            .collect();
+        let loser_bets: alloc::vec::Vec<i128> = (0..num_losers)
+            .map(|_| rng.next_in(10_000) as i128)
+            .collect();
+
+        let total_a: i128 = winner_bets.iter().sum();
+        let total_b: i128 = loser_bets.iter().sum();
+        let total_pool = total_a + total_b;
+
+        // Skip degenerate cases where a side is empty
+        if total_b == 0 || total_a == 0 {
+            continue;
+        }
+
+        for (w, &bet) in winners.iter().zip(winner_bets.iter()) {
+            mint_fuzz(&t.env, &t.token, w, bet);
+            t.client.place_bet(w, &pool_id, &0u32, &bet);
+        }
+        for (l, &bet) in losers.iter().zip(loser_bets.iter()) {
+            mint_fuzz(&t.env, &t.token, l, bet);
+            t.client.place_bet(l, &pool_id, &1u32, &bet);
+        }
+
+        expire_fuzz(&t.env);
+        t.client.settle_pool(&creator, &pool_id, &0u32); // A wins
+
+        let fee = (total_pool * 200) / 10_000;
+        let net = total_pool - fee;
+
+        let mut total_paid_out = 0i128;
+
+        for (w, &bet) in winners.iter().zip(winner_bets.iter()) {
+            let expected = (bet * net) / total_a;
+            let actual = t.client.claim_winnings(w, &pool_id);
+            assert_eq!(
+                actual, expected,
+                "fuzz iteration {iteration}: winner payout mismatch (bet={bet}, total_a={total_a}, net={net})"
+            );
+            total_paid_out += actual;
+        }
+
+        // Losers must not be able to claim
+        for l in &losers {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                t.client.claim_winnings(l, &pool_id);
+            }));
+            assert!(
+                result.is_err(),
+                "fuzz iteration {iteration}: loser claim must panic"
+            );
+        }
+
+        // Treasury + total_paid_out must equal total_pool
+        let treasury = t.client.get_treasury_balance();
+        assert_eq!(
+            treasury + total_paid_out,
+            total_pool,
+            "fuzz iteration {iteration}: treasury + payouts must equal total pool"
+        );
+    }
+}
+
+/// P5: Seeded edge-case distribution — verify expected payout math is reproduced.
+///
+/// This test pins a specific deterministic distribution and hard-codes the
+/// expected outputs so regressions are immediately visible.
+///
+/// Distribution:
+///   - 3 winners on outcome A: 100, 200, 700 tokens
+///   - 2 losers on outcome B:  400, 600 tokens
+///   - total_a = 1000, total_b = 1000, total = 2000
+///   - fee (2%) = 40, net = 1960
+///   - winner payouts: 100*1960/1000=196, 200*1960/1000=392, 700*1960/1000=1372
+#[test]
+fn p5_seeded_edge_case_distribution_reproduces_expected_math() {
+    let t = setup_fuzz();
+    let (pool_id, creator) = make_pool_fuzz(&t);
+
+    let winner1 = Address::generate(&t.env);
+    let winner2 = Address::generate(&t.env);
+    let winner3 = Address::generate(&t.env);
+    let loser1 = Address::generate(&t.env);
+    let loser2 = Address::generate(&t.env);
+
+    mint_fuzz(&t.env, &t.token, &winner1, 100);
+    mint_fuzz(&t.env, &t.token, &winner2, 200);
+    mint_fuzz(&t.env, &t.token, &winner3, 700);
+    mint_fuzz(&t.env, &t.token, &loser1, 400);
+    mint_fuzz(&t.env, &t.token, &loser2, 600);
+
+    t.client.place_bet(&winner1, &pool_id, &0u32, &100i128);
+    t.client.place_bet(&winner2, &pool_id, &0u32, &200i128);
+    t.client.place_bet(&winner3, &pool_id, &0u32, &700i128);
+    t.client.place_bet(&loser1, &pool_id, &1u32, &400i128);
+    t.client.place_bet(&loser2, &pool_id, &1u32, &600i128);
+
+    expire_fuzz(&t.env);
+    t.client.settle_pool(&creator, &pool_id, &0u32);
+
+    // Hard-coded expected values
+    assert_eq!(t.client.claim_winnings(&winner1, &pool_id), 196);
+    assert_eq!(t.client.claim_winnings(&winner2, &pool_id), 392);
+    assert_eq!(t.client.claim_winnings(&winner3, &pool_id), 1372);
+
+    // Treasury must hold fee (40) plus any rounding dust
+    let treasury = t.client.get_treasury_balance();
+    assert!(treasury >= 40, "treasury must hold at least the 2% fee");
+    assert!(treasury <= 42, "treasury must not exceed fee + dust");
+}
+
+/// P6: Payout invariant holds when only one token is on the losing side.
+///
+/// Extreme skew: 1 token on the losing side, large amount on the winning side.
+/// The winner should receive nearly the entire pool minus the fee.
+#[test]
+fn p6_payout_invariant_holds_with_minimal_losing_side() {
+    let t = setup_fuzz();
+    let (pool_id, creator) = make_pool_fuzz(&t);
+
+    let winner = Address::generate(&t.env);
+    let loser = Address::generate(&t.env);
+
+    let total_a = 9_999i128;
+    let total_b = 1i128;
+
+    mint_fuzz(&t.env, &t.token, &winner, total_a);
+    mint_fuzz(&t.env, &t.token, &loser, total_b);
+
+    t.client.place_bet(&winner, &pool_id, &0u32, &total_a);
+    t.client.place_bet(&loser, &pool_id, &1u32, &total_b);
+
+    expire_fuzz(&t.env);
+    t.client.settle_pool(&creator, &pool_id, &0u32);
+
+    let total_pool = total_a + total_b; // 10_000
+    let fee = (total_pool * 200) / 10_000; // 200
+    let net = total_pool - fee; // 9_800
+    let expected = (total_a * net) / total_a; // 9_800
+
+    let actual = t.client.claim_winnings(&winner, &pool_id);
+    assert_eq!(actual, expected, "payout must equal net pool for sole winner");
+}
+
+/// P7: Payout invariant holds when only one token is on the winning side.
+///
+/// Extreme skew: 1 token on the winning side, large amount on the losing side.
+/// The sole winner should receive the entire net pool.
+#[test]
+fn p7_payout_invariant_holds_with_minimal_winning_side() {
+    let t = setup_fuzz();
+    let (pool_id, creator) = make_pool_fuzz(&t);
+
+    let winner = Address::generate(&t.env);
+    let loser = Address::generate(&t.env);
+
+    let total_a = 1i128;
+    let total_b = 9_999i128;
+
+    mint_fuzz(&t.env, &t.token, &winner, total_a);
+    mint_fuzz(&t.env, &t.token, &loser, total_b);
+
+    t.client.place_bet(&winner, &pool_id, &0u32, &total_a);
+    t.client.place_bet(&loser, &pool_id, &1u32, &total_b);
+
+    expire_fuzz(&t.env);
+    t.client.settle_pool(&creator, &pool_id, &0u32);
+
+    let total_pool = total_a + total_b; // 10_000
+    let fee = (total_pool * 200) / 10_000; // 200
+    let net = total_pool - fee; // 9_800
+    let expected = (total_a * net) / total_a; // 9_800
+
+    let actual = t.client.claim_winnings(&winner, &pool_id);
+    assert_eq!(actual, expected, "sole winner must receive the full net pool");
+}
+
+/// P8: Fee is zero when protocol fee is set to 0 bps.
+///
+/// With a 0% fee the winner receives the entire pool and the treasury stays at 0.
+#[test]
+fn p8_zero_fee_winner_receives_entire_pool() {
+    let t = setup_fuzz();
+    let (pool_id, creator) = make_pool_fuzz(&t);
+
+    // Set fee to 0 — treasury_recipient is the token_admin used in setup_fuzz
+    let config = t.client.get_config();
+    t.client.set_protocol_fee(&config.treasury_recipient, &0u32);
+
+    let winner = Address::generate(&t.env);
+    let loser = Address::generate(&t.env);
+
+    mint_fuzz(&t.env, &t.token, &winner, 500);
+    mint_fuzz(&t.env, &t.token, &loser, 500);
+
+    t.client.place_bet(&winner, &pool_id, &0u32, &500i128);
+    t.client.place_bet(&loser, &pool_id, &1u32, &500i128);
+
+    expire_fuzz(&t.env);
+    t.client.settle_pool(&creator, &pool_id, &0u32);
+
+    let actual = t.client.claim_winnings(&winner, &pool_id);
+    assert_eq!(actual, 1000i128, "with 0% fee winner must receive entire pool");
+    assert_eq!(
+        t.client.get_treasury_balance(),
+        0i128,
+        "treasury must be 0 with 0% fee"
+    );
+}
+
+/// P9: Fee is capped at 10% (1000 bps) and payout formula still holds.
+#[test]
+fn p9_max_fee_payout_formula_holds() {
+    let t = setup_fuzz();
+    let (pool_id, creator) = make_pool_fuzz(&t);
+
+    let config = t.client.get_config();
+    t.client
+        .set_protocol_fee(&config.treasury_recipient, &1000u32); // 10%
+
+    let winner = Address::generate(&t.env);
+    let loser = Address::generate(&t.env);
+
+    mint_fuzz(&t.env, &t.token, &winner, 600);
+    mint_fuzz(&t.env, &t.token, &loser, 400);
+
+    t.client.place_bet(&winner, &pool_id, &0u32, &600i128);
+    t.client.place_bet(&loser, &pool_id, &1u32, &400i128);
+
+    expire_fuzz(&t.env);
+    t.client.settle_pool(&creator, &pool_id, &0u32);
+
+    let total_pool = 1000i128;
+    let fee = (total_pool * 1000) / 10_000; // 100
+    let net = total_pool - fee; // 900
+    let expected = (600i128 * net) / 600i128; // 900
+
+    let actual = t.client.claim_winnings(&winner, &pool_id);
+    assert_eq!(actual, expected, "payout must use the configured 10% fee");
+
+    let treasury = t.client.get_treasury_balance();
+    assert!(treasury >= fee, "treasury must hold at least the 10% fee");
+}
+
+/// P10: Sum of all winner payouts plus treasury equals total pool for a
+///      randomly generated multi-winner, multi-loser distribution.
+///
+/// This is the core conservation invariant: no tokens are created or destroyed.
+#[test]
+fn p10_conservation_invariant_holds_for_random_distribution() {
+    let mut rng = Lcg::new(0xFEED_FACE_DEAD_BEEF);
+
+    for iteration in 0..20u32 {
+        let num_winners = (rng.next_in(5) + 1) as usize; // 2–6
+        let num_losers = (rng.next_in(4) + 1) as usize; // 2–5
+
+        let t = setup_fuzz();
+        let (pool_id, creator) = make_pool_fuzz(&t);
+
+        let winners: alloc::vec::Vec<Address> = (0..num_winners)
+            .map(|_| Address::generate(&t.env))
+            .collect();
+        let losers: alloc::vec::Vec<Address> = (0..num_losers)
+            .map(|_| Address::generate(&t.env))
+            .collect();
+
+        let winner_bets: alloc::vec::Vec<i128> = (0..num_winners)
+            .map(|_| rng.next_in(5_000) as i128)
+            .collect();
+        let loser_bets: alloc::vec::Vec<i128> = (0..num_losers)
+            .map(|_| rng.next_in(5_000) as i128)
+            .collect();
+
+        let total_a: i128 = winner_bets.iter().sum();
+        let total_b: i128 = loser_bets.iter().sum();
+
+        if total_a == 0 || total_b == 0 {
+            continue;
+        }
+
+        for (w, &bet) in winners.iter().zip(winner_bets.iter()) {
+            mint_fuzz(&t.env, &t.token, w, bet);
+            t.client.place_bet(w, &pool_id, &0u32, &bet);
+        }
+        for (l, &bet) in losers.iter().zip(loser_bets.iter()) {
+            mint_fuzz(&t.env, &t.token, l, bet);
+            t.client.place_bet(l, &pool_id, &1u32, &bet);
+        }
+
+        expire_fuzz(&t.env);
+        t.client.settle_pool(&creator, &pool_id, &0u32);
+
+        let total_pool = total_a + total_b;
+        let mut total_paid_out = 0i128;
+
+        for w in &winners {
+            let payout = t.client.claim_winnings(w, &pool_id);
+            total_paid_out += payout;
+        }
+
+        let treasury = t.client.get_treasury_balance();
+
+        assert_eq!(
+            treasury + total_paid_out,
+            total_pool,
+            "conservation invariant violated at iteration {iteration}: \
+             treasury({treasury}) + paid_out({total_paid_out}) != total_pool({total_pool})"
+        );
+    }
+}

--- a/contracts/predinex/src/lib.rs
+++ b/contracts/predinex/src/lib.rs
@@ -3,6 +3,8 @@ extern crate alloc;
 use alloc::vec;
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, String, Symbol, Vec};
 
+mod fuzz_tests;
+mod multi_user_tests;
 mod pause_tests;
 mod protocol_fee_tests;
 mod test;

--- a/contracts/predinex/src/multi_user_tests.rs
+++ b/contracts/predinex/src/multi_user_tests.rs
@@ -1,0 +1,542 @@
+// ============================================================================
+// Issue #188: Multi-user accumulation tests with repeated bets across both sides
+//
+// These tests stress repeated betting over time from many actors, verifying
+// that stored pool totals and per-user totals stay correct after every step,
+// and that final settlement and claim logic works after the accumulation
+// sequence.
+// ============================================================================
+
+#![cfg(test)]
+extern crate std;
+use super::*;
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, String};
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+struct MultiUserEnv<'a> {
+    env: Env,
+    client: PredinexContractClient<'a>,
+    token: Address,
+    contract_id: Address,
+}
+
+fn setup_multi_user() -> MultiUserEnv<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+
+    let contract_id = env.register(PredinexContract, ());
+    let client = PredinexContractClient::new(&env, &contract_id);
+
+    client.initialize(&token_id.address(), &token_admin);
+
+    let client: PredinexContractClient<'static> = unsafe { core::mem::transmute(client) };
+
+    MultiUserEnv {
+        env,
+        client,
+        token: token_id.address(),
+        contract_id,
+    }
+}
+
+/// Mint tokens to a user via the token admin.
+fn mint(env: &Env, token: &Address, user: &Address, amount: i128) {
+    let admin = soroban_sdk::token::StellarAssetClient::new(env, token);
+    admin.mint(user, &amount);
+}
+
+/// Create a standard 1-hour pool and return its ID.
+fn make_pool_mu(t: &MultiUserEnv) -> u32 {
+    let creator = Address::generate(&t.env);
+    t.client.create_pool(
+        &creator,
+        &String::from_str(&t.env, "Accumulation Pool"),
+        &String::from_str(&t.env, "Multi-user stress test"),
+        &String::from_str(&t.env, "Yes"),
+        &String::from_str(&t.env, "No"),
+        &3_600u64,
+    )
+}
+
+/// Advance the ledger past the pool expiry.
+fn expire_mu(env: &Env) {
+    env.ledger().with_mut(|li| {
+        li.timestamp = 7_200;
+    });
+}
+
+// ── Suite M — multi-user accumulation ────────────────────────────────────────
+
+/// M1: Pool totals accumulate correctly across many users betting on both sides.
+///
+/// Five users each place two bets (one on each outcome). After all bets the
+/// pool totals must equal the sum of every individual bet.
+#[test]
+fn m1_pool_totals_accumulate_across_many_users() {
+    let t = setup_multi_user();
+    let pool_id = make_pool_mu(&t);
+
+    let users: alloc::vec::Vec<Address> = (0..5).map(|_| Address::generate(&t.env)).collect();
+    let bet_a = 100i128;
+    let bet_b = 200i128;
+
+    for user in &users {
+        mint(&t.env, &t.token, user, bet_a + bet_b);
+        t.client.place_bet(user, &pool_id, &0u32, &bet_a);
+        t.client.place_bet(user, &pool_id, &1u32, &bet_b);
+    }
+
+    let pool = t.client.get_pool(&pool_id).expect("pool must exist");
+    let expected_a = bet_a * users.len() as i128;
+    let expected_b = bet_b * users.len() as i128;
+
+    assert_eq!(
+        pool.total_a, expected_a,
+        "total_a must equal sum of all outcome-A bets"
+    );
+    assert_eq!(
+        pool.total_b, expected_b,
+        "total_b must equal sum of all outcome-B bets"
+    );
+}
+
+/// M2: Per-user bet records stay correct after repeated bets on both sides.
+///
+/// A single user places multiple bets on each outcome in alternating order.
+/// The stored `amount_a`, `amount_b`, and `total_bet` must reflect the running
+/// cumulative totals after every individual bet.
+#[test]
+fn m2_per_user_totals_stay_correct_after_repeated_bets() {
+    let t = setup_multi_user();
+    let pool_id = make_pool_mu(&t);
+
+    let user = Address::generate(&t.env);
+    mint(&t.env, &t.token, &user, 10_000);
+
+    // Interleave bets on both outcomes
+    let bets: &[(u32, i128)] = &[
+        (0, 100),
+        (1, 200),
+        (0, 150),
+        (1, 50),
+        (0, 300),
+        (1, 400),
+    ];
+
+    let mut expected_a = 0i128;
+    let mut expected_b = 0i128;
+
+    for &(outcome, amount) in bets {
+        t.client.place_bet(&user, &pool_id, &outcome, &amount);
+        if outcome == 0 {
+            expected_a += amount;
+        } else {
+            expected_b += amount;
+        }
+
+        let bet = t
+            .client
+            .get_user_bet(&pool_id, &user)
+            .expect("bet must exist");
+        assert_eq!(
+            bet.amount_a, expected_a,
+            "amount_a must match running total after each bet"
+        );
+        assert_eq!(
+            bet.amount_b, expected_b,
+            "amount_b must match running total after each bet"
+        );
+        assert_eq!(
+            bet.total_bet,
+            expected_a + expected_b,
+            "total_bet must equal sum of both sides"
+        );
+    }
+}
+
+/// M3: Participant count increments once per new user, not once per bet.
+///
+/// Three users each place multiple bets. The participant count must equal 3,
+/// not the total number of bet calls.
+#[test]
+fn m3_participant_count_increments_once_per_user() {
+    let t = setup_multi_user();
+    let pool_id = make_pool_mu(&t);
+
+    let user1 = Address::generate(&t.env);
+    let user2 = Address::generate(&t.env);
+    let user3 = Address::generate(&t.env);
+
+    for user in [&user1, &user2, &user3] {
+        mint(&t.env, &t.token, user, 1_000);
+    }
+
+    // Each user places two bets
+    t.client.place_bet(&user1, &pool_id, &0u32, &100i128);
+    t.client.place_bet(&user1, &pool_id, &1u32, &100i128);
+    t.client.place_bet(&user2, &pool_id, &0u32, &200i128);
+    t.client.place_bet(&user2, &pool_id, &1u32, &200i128);
+    t.client.place_bet(&user3, &pool_id, &0u32, &300i128);
+    t.client.place_bet(&user3, &pool_id, &1u32, &300i128);
+
+    let pool = t.client.get_pool(&pool_id).expect("pool must exist");
+    assert_eq!(
+        pool.participant_count, 3,
+        "participant_count must be 3 (one per unique user)"
+    );
+}
+
+/// M4: Settlement and claim payouts are correct after a multi-user accumulation.
+///
+/// Four users bet on outcome A, two users bet on outcome B. Outcome A wins.
+/// Each winner's payout must equal their proportional share of the net pool.
+#[test]
+fn m4_settlement_and_claims_correct_after_accumulation() {
+    let t = setup_multi_user();
+    let pool_id = make_pool_mu(&t);
+
+    // Winners bet on outcome A
+    let winners: alloc::vec::Vec<Address> =
+        (0..4).map(|_| Address::generate(&t.env)).collect();
+    // Losers bet on outcome B
+    let losers: alloc::vec::Vec<Address> =
+        (0..2).map(|_| Address::generate(&t.env)).collect();
+
+    let winner_bet = 250i128;
+    let loser_bet = 500i128;
+
+    for w in &winners {
+        mint(&t.env, &t.token, w, winner_bet);
+        t.client.place_bet(w, &pool_id, &0u32, &winner_bet);
+    }
+    for l in &losers {
+        mint(&t.env, &t.token, l, loser_bet);
+        t.client.place_bet(l, &pool_id, &1u32, &loser_bet);
+    }
+
+    // total_a = 4 * 250 = 1000, total_b = 2 * 500 = 1000, total = 2000
+    let total_a = winner_bet * winners.len() as i128; // 1000
+    let total_b = loser_bet * losers.len() as i128; // 1000
+    let total_pool = total_a + total_b; // 2000
+    let fee = (total_pool * 200) / 10_000; // 2% = 40
+    let net = total_pool - fee; // 1960
+
+    expire_mu(&t.env);
+
+    // Settle with outcome 0 (A wins) — creator is the pool creator address
+    let pool = t.client.get_pool(&pool_id).expect("pool must exist");
+    let creator = pool.creator.clone();
+    t.client.settle_pool(&creator, &pool_id, &0u32);
+
+    // Each winner's expected payout: winner_bet * net / total_a
+    let expected_payout = (winner_bet * net) / total_a; // 250 * 1960 / 1000 = 490
+
+    let token_client = soroban_sdk::token::Client::new(&t.env, &t.token);
+
+    for w in &winners {
+        let winnings = t.client.claim_winnings(w, &pool_id);
+        assert_eq!(
+            winnings, expected_payout,
+            "each winner must receive their proportional share"
+        );
+        assert_eq!(
+            token_client.balance(w),
+            expected_payout,
+            "winner token balance must equal payout"
+        );
+    }
+
+    // Losers must not be able to claim
+    for l in &losers {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            t.client.claim_winnings(l, &pool_id);
+        }));
+        assert!(result.is_err(), "loser claim must panic");
+    }
+}
+
+/// M5: Pool totals stay correct when users place many small repeated bets.
+///
+/// Ten users each place ten bets of 10 tokens on outcome A. The pool total_a
+/// must equal 10 * 10 * 10 = 1000 and total_b must remain 0.
+#[test]
+fn m5_pool_totals_correct_with_many_small_repeated_bets() {
+    let t = setup_multi_user();
+    let pool_id = make_pool_mu(&t);
+
+    let num_users = 10usize;
+    let bets_per_user = 10usize;
+    let bet_amount = 10i128;
+
+    let users: alloc::vec::Vec<Address> = (0..num_users)
+        .map(|_| Address::generate(&t.env))
+        .collect();
+
+    for user in &users {
+        mint(
+            &t.env,
+            &t.token,
+            user,
+            bet_amount * bets_per_user as i128,
+        );
+        for _ in 0..bets_per_user {
+            t.client.place_bet(user, &pool_id, &0u32, &bet_amount);
+        }
+    }
+
+    let pool = t.client.get_pool(&pool_id).expect("pool must exist");
+    let expected_total_a = bet_amount * (num_users * bets_per_user) as i128;
+
+    assert_eq!(
+        pool.total_a, expected_total_a,
+        "total_a must equal sum of all small bets"
+    );
+    assert_eq!(pool.total_b, 0i128, "total_b must remain 0");
+}
+
+/// M6: Asymmetric multi-user accumulation — unequal bets on both sides.
+///
+/// Users place varying amounts on both outcomes. After settlement the winner
+/// with the largest stake receives the largest payout, proportional to their
+/// share of the winning side.
+#[test]
+fn m6_asymmetric_accumulation_payouts_are_proportional() {
+    let t = setup_multi_user();
+    let pool_id = make_pool_mu(&t);
+
+    // Three winners with different stakes on outcome A
+    let winner1 = Address::generate(&t.env);
+    let winner2 = Address::generate(&t.env);
+    let winner3 = Address::generate(&t.env);
+    // One loser on outcome B
+    let loser = Address::generate(&t.env);
+
+    mint(&t.env, &t.token, &winner1, 100);
+    mint(&t.env, &t.token, &winner2, 300);
+    mint(&t.env, &t.token, &winner3, 600);
+    mint(&t.env, &t.token, &loser, 400);
+
+    t.client.place_bet(&winner1, &pool_id, &0u32, &100i128);
+    t.client.place_bet(&winner2, &pool_id, &0u32, &300i128);
+    t.client.place_bet(&winner3, &pool_id, &0u32, &600i128);
+    t.client.place_bet(&loser, &pool_id, &1u32, &400i128);
+
+    // total_a = 1000, total_b = 400, total = 1400
+    let total_pool = 1400i128;
+    let fee = (total_pool * 200) / 10_000; // 28
+    let net = total_pool - fee; // 1372
+    let total_a = 1000i128;
+
+    expire_mu(&t.env);
+
+    let pool = t.client.get_pool(&pool_id).expect("pool must exist");
+    let creator = pool.creator.clone();
+    t.client.settle_pool(&creator, &pool_id, &0u32);
+
+    // Expected payouts proportional to stake
+    let payout1 = (100i128 * net) / total_a; // 100 * 1372 / 1000 = 137
+    let payout2 = (300i128 * net) / total_a; // 300 * 1372 / 1000 = 411
+    let payout3 = (600i128 * net) / total_a; // 600 * 1372 / 1000 = 823
+
+    assert_eq!(
+        t.client.claim_winnings(&winner1, &pool_id),
+        payout1,
+        "winner1 payout must be proportional to their stake"
+    );
+    assert_eq!(
+        t.client.claim_winnings(&winner2, &pool_id),
+        payout2,
+        "winner2 payout must be proportional to their stake"
+    );
+    assert_eq!(
+        t.client.claim_winnings(&winner3, &pool_id),
+        payout3,
+        "winner3 payout must be proportional to their stake"
+    );
+
+    // Loser cannot claim
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        t.client.claim_winnings(&loser, &pool_id);
+    }));
+    assert!(result.is_err(), "loser claim must panic");
+}
+
+/// M7: Treasury balance equals the protocol fee after all winners claim.
+///
+/// After a full accumulation + settlement + all-claims cycle, the treasury
+/// must hold exactly the protocol fee (plus any rounding dust).
+#[test]
+fn m7_treasury_equals_fee_after_all_claims() {
+    let t = setup_multi_user();
+    let pool_id = make_pool_mu(&t);
+
+    let winners: alloc::vec::Vec<Address> =
+        (0..3).map(|_| Address::generate(&t.env)).collect();
+    let loser = Address::generate(&t.env);
+
+    let winner_bet = 200i128;
+    let loser_bet = 300i128;
+
+    for w in &winners {
+        mint(&t.env, &t.token, w, winner_bet);
+        t.client.place_bet(w, &pool_id, &0u32, &winner_bet);
+    }
+    mint(&t.env, &t.token, &loser, loser_bet);
+    t.client.place_bet(&loser, &pool_id, &1u32, &loser_bet);
+
+    // total = 3*200 + 300 = 900
+    let total_pool = 900i128;
+    let expected_fee = (total_pool * 200) / 10_000; // 18
+
+    expire_mu(&t.env);
+
+    let pool = t.client.get_pool(&pool_id).expect("pool must exist");
+    let creator = pool.creator.clone();
+    t.client.settle_pool(&creator, &pool_id, &0u32);
+
+    // All winners claim
+    for w in &winners {
+        t.client.claim_winnings(w, &pool_id);
+    }
+
+    let treasury = t.client.get_treasury_balance();
+    // Treasury must hold the fee (plus any integer-division dust, which is ≥ 0)
+    assert!(
+        treasury >= expected_fee,
+        "treasury must hold at least the protocol fee"
+    );
+    // And must not exceed fee + (n_winners - 1) dust tokens
+    assert!(
+        treasury <= expected_fee + (winners.len() as i128 - 1),
+        "treasury must not exceed fee plus rounding dust"
+    );
+}
+
+/// M8: Multiple pools accumulate independently — bets in one pool do not
+/// affect totals in another.
+#[test]
+fn m8_multiple_pools_accumulate_independently() {
+    let t = setup_multi_user();
+
+    let pool_a = make_pool_mu(&t);
+    let pool_b = make_pool_mu(&t);
+
+    let user1 = Address::generate(&t.env);
+    let user2 = Address::generate(&t.env);
+
+    mint(&t.env, &t.token, &user1, 1_000);
+    mint(&t.env, &t.token, &user2, 1_000);
+
+    // user1 bets only in pool_a
+    t.client.place_bet(&user1, &pool_a, &0u32, &400i128);
+    // user2 bets only in pool_b
+    t.client.place_bet(&user2, &pool_b, &1u32, &600i128);
+
+    let pa = t.client.get_pool(&pool_a).expect("pool_a must exist");
+    let pb = t.client.get_pool(&pool_b).expect("pool_b must exist");
+
+    assert_eq!(pa.total_a, 400i128, "pool_a total_a must be 400");
+    assert_eq!(pa.total_b, 0i128, "pool_a total_b must be 0");
+    assert_eq!(pb.total_a, 0i128, "pool_b total_a must be 0");
+    assert_eq!(pb.total_b, 600i128, "pool_b total_b must be 600");
+}
+
+/// M9: A user who bets on both sides in the same pool can only claim winnings
+/// for the winning side.
+#[test]
+fn m9_user_betting_both_sides_claims_only_winning_side() {
+    let t = setup_multi_user();
+    let pool_id = make_pool_mu(&t);
+
+    let user = Address::generate(&t.env);
+    let other = Address::generate(&t.env);
+
+    mint(&t.env, &t.token, &user, 1_000);
+    mint(&t.env, &t.token, &other, 500);
+
+    // User bets on both sides
+    t.client.place_bet(&user, &pool_id, &0u32, &300i128); // outcome A
+    t.client.place_bet(&user, &pool_id, &1u32, &200i128); // outcome B
+    // Other user bets on B to ensure there is a losing side
+    t.client.place_bet(&other, &pool_id, &1u32, &500i128);
+
+    // total_a = 300, total_b = 700, total = 1000
+    let total_pool = 1000i128;
+    let fee = (total_pool * 200) / 10_000; // 20
+    let net = total_pool - fee; // 980
+    let total_a = 300i128;
+
+    expire_mu(&t.env);
+
+    let pool = t.client.get_pool(&pool_id).expect("pool must exist");
+    let creator = pool.creator.clone();
+    t.client.settle_pool(&creator, &pool_id, &0u32); // A wins
+
+    // User's winning stake is 300 (outcome A)
+    let expected_payout = (300i128 * net) / total_a; // 300 * 980 / 300 = 980
+    let winnings = t.client.claim_winnings(&user, &pool_id);
+
+    assert_eq!(
+        winnings, expected_payout,
+        "user must receive payout based on winning-side stake only"
+    );
+}
+
+/// M10: Accumulation sequence — verify pool state after every individual bet.
+///
+/// Three users each place three bets in sequence. After each bet the pool
+/// totals are read and verified to match the running expected values.
+#[test]
+fn m10_pool_state_verified_after_every_bet_in_sequence() {
+    let t = setup_multi_user();
+    let pool_id = make_pool_mu(&t);
+
+    let user1 = Address::generate(&t.env);
+    let user2 = Address::generate(&t.env);
+    let user3 = Address::generate(&t.env);
+
+    for u in [&user1, &user2, &user3] {
+        mint(&t.env, &t.token, u, 3_000);
+    }
+
+    // Sequence of (user_index, outcome, amount)
+    let sequence: &[(usize, u32, i128)] = &[
+        (0, 0, 100),
+        (1, 1, 200),
+        (2, 0, 150),
+        (0, 1, 300),
+        (1, 0, 250),
+        (2, 1, 400),
+        (0, 0, 50),
+        (1, 1, 100),
+        (2, 0, 200),
+    ];
+
+    let users = [&user1, &user2, &user3];
+    let mut running_a = 0i128;
+    let mut running_b = 0i128;
+
+    for &(user_idx, outcome, amount) in sequence {
+        t.client
+            .place_bet(users[user_idx], &pool_id, &outcome, &amount);
+        if outcome == 0 {
+            running_a += amount;
+        } else {
+            running_b += amount;
+        }
+
+        let pool = t.client.get_pool(&pool_id).expect("pool must exist");
+        assert_eq!(
+            pool.total_a, running_a,
+            "total_a must match running sum after each bet"
+        );
+        assert_eq!(
+            pool.total_b, running_b,
+            "total_b must match running sum after each bet"
+        );
+    }
+}


### PR DESCRIPTION


## Issue #188 — Multi-user accumulation tests (multi_user_tests.rs)

- M1: pool totals accumulate correctly across 5 users betting on both sides
- M2: per-user amount_a/amount_b/total_bet stay correct after every interleaved bet
- M3: participant_count increments once per unique user, not per bet call
- M4: settlement and claim payouts correct after 4-winner / 2-loser accumulation
- M5: pool totals correct with 10 users x 10 small bets each
- M6: asymmetric accumulation — payouts proportional to each winner's stake
- M7: treasury holds exactly the protocol fee after all winners claim
- M8: multiple pools accumulate independently without cross-contamination
- M9: user betting both sides can only claim the winning-side payout
- M10: pool state verified after every individual bet in a 9-step mixed sequence

## Issue #182 — Fuzz / property tests (fuzz_tests.rs)

Uses a seeded deterministic LCG (no external crates, CI-safe):

- P1: payout formula holds for 11 hand-crafted uneven distributions
- P2: fee accounting correct for 9 diverse pool sizes
- P3: deterministic fuzz — 50 single-winner distributions
- P4: deterministic fuzz — 30 multi-winner distributions
- P5: seeded edge-case reproduces hard-coded expected math
- P6: payout invariant with minimal (1-token) losing side
- P7: payout invariant with minimal (1-token) winning side
- P8: 0% fee — winner receives entire pool, treasury stays at 0
- P9: 10% (max) fee — payout formula still holds
- P10: conservation invariant (treasury + payouts == total_pool) for 20 random distributions

## Test result

cargo test --package predinex: 141 passed, 0 failed.

Close #188 
Close #182.