### PR TITLE
test(web): enforce client runtime env boundary guardrails

### DIFF
--- a/web/DEVELOPMENT.md
+++ b/web/DEVELOPMENT.md
@@ -24,6 +24,8 @@ This document provides instructions for developers looking to contribute to the 
    NEXT_PUBLIC_NETWORK=testnet
    ```
 
+   Runtime config boundaries are enforced by tests. Before adding a new client-exposed env key, update `app/lib/env-boundary.ts` and `docs/RUNTIME_CONFIG_BOUNDARIES.md`.
+
 3. **Run Development Server**:
    ```bash
    npm run dev

--- a/web/app/lib/env-boundary.ts
+++ b/web/app/lib/env-boundary.ts
@@ -1,0 +1,33 @@
+export const CLIENT_SAFE_RUNTIME_ENV_KEYS = [
+  'NEXT_PUBLIC_APP_URL',
+  'NEXT_PUBLIC_CONTRACT_ADDRESS',
+  'NEXT_PUBLIC_CONTRACT_NAME',
+  'NEXT_PUBLIC_ENABLE_ORACLE_MANAGEMENT_PLACEHOLDER',
+  'NEXT_PUBLIC_NETWORK',
+  'NEXT_PUBLIC_SOROBAN_CONTRACT_ID',
+  'NEXT_PUBLIC_STACKS_API_URL',
+  'NEXT_PUBLIC_TOKEN_NAME',
+  'NEXT_PUBLIC_TOKEN_SYMBOL',
+  'NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID',
+] as const;
+
+export const CLIENT_BUILD_SYSTEM_ENV_KEYS = ['NODE_ENV', 'CI'] as const;
+
+export const CLIENT_ALLOWED_ENV_KEYS = [
+  ...CLIENT_SAFE_RUNTIME_ENV_KEYS,
+  ...CLIENT_BUILD_SYSTEM_ENV_KEYS,
+] as const;
+
+const CLIENT_ALLOWED_ENV_KEY_SET = new Set<string>(CLIENT_ALLOWED_ENV_KEYS);
+
+export function assertClientEnvAccessIsSafe(keys: Iterable<string>): void {
+  const disallowed = [...new Set(keys)].filter((key) => !CLIENT_ALLOWED_ENV_KEY_SET.has(key)).sort();
+  if (disallowed.length > 0) {
+    throw new Error(
+      `Disallowed client env access detected: ${disallowed.join(
+        ', '
+      )}. Only documented NEXT_PUBLIC_* runtime values and build-time NODE_ENV/CI are allowed.`
+    );
+  }
+}
+

--- a/web/docs/RUNTIME_CONFIG_BOUNDARIES.md
+++ b/web/docs/RUNTIME_CONFIG_BOUNDARIES.md
@@ -1,0 +1,43 @@
+# Runtime Config Boundaries
+
+This document defines which environment values are safe to expose in browser bundles and which values must stay server-only.
+
+## Client-safe runtime config
+
+Only these `NEXT_PUBLIC_*` keys are allowed in client source:
+
+- `NEXT_PUBLIC_APP_URL`
+- `NEXT_PUBLIC_CONTRACT_ADDRESS`
+- `NEXT_PUBLIC_CONTRACT_NAME`
+- `NEXT_PUBLIC_ENABLE_ORACLE_MANAGEMENT_PLACEHOLDER`
+- `NEXT_PUBLIC_NETWORK`
+- `NEXT_PUBLIC_SOROBAN_CONTRACT_ID`
+- `NEXT_PUBLIC_STACKS_API_URL`
+- `NEXT_PUBLIC_TOKEN_NAME`
+- `NEXT_PUBLIC_TOKEN_SYMBOL`
+- `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID`
+
+## Build-time system keys in client source
+
+These keys are read only for build/runtime mode checks and are not application secrets:
+
+- `NODE_ENV`
+- `CI`
+
+## Server-only config
+
+Any environment key not listed above is treated as server-only and must never be read from client modules.
+
+Examples:
+
+- `DATABASE_URL`
+- `JWT_SECRET`
+- `PRIVATE_KEY`
+- `REDIS_URL`
+
+## Guardrails
+
+- `app/lib/env-boundary.ts` is the single allowlist for client env usage.
+- `tests/lib/env-boundary.test.ts` scans `app/` and `lib/` source and fails if a non-allowlisted key is accessed through `process.env`.
+- The test suite also includes a controlled negative test to verify server-only key exposure is rejected.
+

--- a/web/tests/lib/env-boundary.test.ts
+++ b/web/tests/lib/env-boundary.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  assertClientEnvAccessIsSafe,
+  CLIENT_SAFE_RUNTIME_ENV_KEYS,
+} from '../../app/lib/env-boundary';
+
+const CLIENT_SOURCE_ROOTS = ['app', 'lib'];
+const SOURCE_FILE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+const ENV_ACCESS_PATTERN = /process\.env\.([A-Z0-9_]+)/g;
+
+function walkSourceFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkSourceFiles(fullPath));
+      continue;
+    }
+
+    if (SOURCE_FILE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function collectClientEnvAccesses(webRoot: string): string[] {
+  const accesses: string[] = [];
+  for (const root of CLIENT_SOURCE_ROOTS) {
+    const rootPath = path.join(webRoot, root);
+    if (!fs.existsSync(rootPath)) continue;
+
+    for (const filePath of walkSourceFiles(rootPath)) {
+      const content = fs.readFileSync(filePath, 'utf8');
+      for (const match of content.matchAll(ENV_ACCESS_PATTERN)) {
+        accesses.push(match[1]);
+      }
+    }
+  }
+  return accesses;
+}
+
+describe('env boundary guardrails', () => {
+  const currentFilePath = fileURLToPath(import.meta.url);
+  const currentDirPath = path.dirname(currentFilePath);
+  const webRoot = path.resolve(currentDirPath, '..', '..');
+
+  it('allows only documented public runtime config keys in client source', () => {
+    const accessedEnvKeys = collectClientEnvAccesses(webRoot);
+    expect(accessedEnvKeys.length).toBeGreaterThan(0);
+    expect(() => assertClientEnvAccessIsSafe(accessedEnvKeys)).not.toThrow();
+  });
+
+  it('documents the public runtime keys that are safe to expose', () => {
+    expect(CLIENT_SAFE_RUNTIME_ENV_KEYS).toMatchInlineSnapshot(`
+      [
+        "NEXT_PUBLIC_APP_URL",
+        "NEXT_PUBLIC_CONTRACT_ADDRESS",
+        "NEXT_PUBLIC_CONTRACT_NAME",
+        "NEXT_PUBLIC_ENABLE_ORACLE_MANAGEMENT_PLACEHOLDER",
+        "NEXT_PUBLIC_NETWORK",
+        "NEXT_PUBLIC_SOROBAN_CONTRACT_ID",
+        "NEXT_PUBLIC_STACKS_API_URL",
+        "NEXT_PUBLIC_TOKEN_NAME",
+        "NEXT_PUBLIC_TOKEN_SYMBOL",
+        "NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID",
+      ]
+    `);
+  });
+
+  it('catches accidental server-only env access before it reaches client bundles', () => {
+    const candidateClientAccesses = ['NEXT_PUBLIC_NETWORK', 'DATABASE_URL'];
+    expect(() => assertClientEnvAccessIsSafe(candidateClientAccesses)).toThrow(
+      /Disallowed client env access detected: DATABASE_URL/
+    );
+  });
+});
+


### PR DESCRIPTION
Add a centralized allowlist for client-safe runtime env keys and a source-scanning test that blocks server-only env access from client modules. Document the approved runtime config surface so future env additions require explicit classification and test coverage.

Made-with: Cursor

## Summary

<!--
Describe what this PR does and why. Link the relevant issue(s):
  Closes #250 
-->

Closes #

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `ci` — CI / workflow changes
- [ ] `chore` — dependency bump or tooling update

## Scope

- [ ] Contract (`contracts/`)
- [ ] Frontend / Web (`web/`)
- [ ] Docs (`docs/`)
- [ ] CI / Ops (`.github/`)

---

## Contract changes (complete if scope includes `contracts/`)

- [ ] New or changed public functions — ABI impact documented below
- [ ] Storage layout changed — migration path described below
- [ ] Tests added or updated for every changed function

**ABI / storage notes:**
<!-- Describe breaking changes or migration steps, or write "N/A". -->

---

## Frontend changes (complete if scope includes `web/`)

- [ ] UI tested in a browser on the happy path
- [ ] Responsive layout verified (mobile / desktop)
- [ ] No new `console.error` or TypeScript errors introduced

---

## Testing

- [ ] Existing tests still pass (`cargo test` / `npm run test`)
- [ ] New tests added for new behaviour
- [ ] Manual steps to verify this change:

<!--
1. …
2. …
-->

## Docs impact

- [ ] README or docs updated (or N/A)
- [ ] Changelog entry added (or N/A)

## Additional notes

<!-- Anything a reviewer should know: trade-offs, follow-up tickets, performance impact, etc. -->
