### PR TITLE
Add i18n, notifications, and exports

### DIFF
--- a/web/app/components/Dashboard.tsx
+++ b/web/app/components/Dashboard.tsx
@@ -6,6 +6,7 @@ import { useWallet } from './WalletAdapterProvider';
 import { useWalletConnect } from '../lib/hooks/useWalletConnect';
 import { useUserDashboard } from '../lib/user-dashboard/useUserDashboard';
 import type { DashboardTabId } from '../lib/user-dashboard/types';
+import { useI18n } from '../lib/i18n';
 import { DashboardConnectPrompt } from './user-dashboard/DashboardConnectPrompt';
 import { DashboardHeader } from './user-dashboard/DashboardHeader';
 import { DashboardStatsSections } from './user-dashboard/DashboardStatsSections';
@@ -34,6 +35,7 @@ const IncentivesDisplay = dynamic(() => import('./IncentivesDisplay'), {
 export default function Dashboard() {
   const { isConnected, address } = useWallet();
   const { session } = useWalletConnect();
+  const { t } = useI18n();
   const [activeTab, setActiveTab] = useState<DashboardTabId>('overview');
 
   const sessionConnected = !!session?.isConnected;
@@ -61,7 +63,7 @@ export default function Dashboard() {
           disabled={isLoading}
           className="flex-1 py-3 bg-primary/10 hover:bg-primary/20 text-primary font-bold rounded-xl transition-all disabled:opacity-50"
         >
-          {isLoading ? 'Refreshing...' : 'Refresh Data'}
+          {isLoading ? t('dashboard.refreshing') : t('dashboard.refresh')}
         </button>
       </div>
 

--- a/web/app/components/Navbar.tsx
+++ b/web/app/components/Navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { LogOut, Menu, X, Wallet, Moon, Sun } from "lucide-react";
 import { useWallet } from './WalletAdapterProvider';
 import { useTheme } from '../context/ThemeContext';
+import { useI18n } from '../lib/i18n';
 import { ICON_CLASS } from "../lib/constants";
 import { WalletAddressCopyButton } from "../../components/WalletAddressCopyButton";
 import { NetworkMismatchWarning } from './NetworkMismatchWarning';
@@ -12,6 +13,7 @@ import { NetworkMismatchWarning } from './NetworkMismatchWarning';
 export default function Navbar() {
     const { isConnected, address, connect, disconnect } = useWallet();
     const { theme, toggleTheme } = useTheme();
+    const { t } = useI18n();
     const [isMenuOpen, setIsMenuOpen] = useState(false);
 
     return (
@@ -21,39 +23,42 @@ export default function Navbar() {
                 <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <div className="flex justify-between items-center h-16">
                         {/* Logo */}
-                        <Link href="/" className="flex items-center gap-2 group" aria-label="Predinex Home">
-                            <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center group-hover:scale-110 transition-transform">
-                                <span className="font-bold text-white">P</span>
+                            <Link href="/" className="flex items-center gap-2 group" aria-label="Predinex Home">
+                                <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center group-hover:scale-110 transition-transform">
+                                    <span className="font-bold text-white">P</span>
+                                </div>
+                                <span className="font-bold text-xl tracking-tight text-gradient">Predinex</span>
+                            </Link>
+                            {/* Navigation Links - Desktop */}
+                            <div className="hidden md:flex items-center gap-6" aria-label="Desktop navigation">
+                                <Link href="/markets" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="View all markets">
+                                {t('nav.markets')}
+                                </Link>
+                                <Link href="/create" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="Create a new prediction market">
+                                {t('nav.create')}
+                                </Link>
+                                {isConnected && (
+                                    <Link href="/transactions" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="View transaction history">
+                                    {t('nav.transactions')}
+                                    </Link>
+                                )}
+                                {isConnected && (
+                                    <Link href="/activity" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="View activity feed">
+                                    {t('nav.activity')}
+                                    </Link>
+                                )}
+                                {isConnected && (
+                                    <Link href="/dashboard" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="User dashboard">
+                                    {t('nav.dashboard')}
+                                    </Link>
+                                )}
+                                <Link href="/analytics" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="Platform analytics">
+                                {t('nav.analytics')}
+                                </Link>
+                                <Link href="/settings" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="Open settings">
+                                {t('nav.settings')}
+                                </Link>
                             </div>
-                            <span className="font-bold text-xl tracking-tight text-gradient">Predinex</span>
-                        </Link>
-                        {/* Navigation Links - Desktop */}
-                        <div className="hidden md:flex items-center gap-6" aria-label="Desktop navigation">
-                            <Link href="/markets" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="View all markets">
-                                Markets
-                            </Link>
-                            <Link href="/create" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="Create a new prediction market">
-                                Create
-                            </Link>
-                            {isConnected && (
-                                <Link href="/transactions" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="View transaction history">
-                                    Transactions
-                                </Link>
-                            )}
-                            {isConnected && (
-                                <Link href="/activity" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="View activity feed">
-                                    Activity
-                                </Link>
-                            )}
-                            {isConnected && (
-                                <Link href="/dashboard" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="User dashboard">
-                                    Dashboard
-                                </Link>
-                            )}
-                            <Link href="/analytics" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors" aria-label="Platform analytics">
-                                Analytics
-                            </Link>
-                        </div>
 
                     {/* User Info & Connect Button - Desktop */}
                     <div className="hidden md:flex items-center gap-4">
@@ -72,7 +77,7 @@ export default function Navbar() {
                                     onClick={disconnect}
                                     className="p-2 bg-red-500/10 hover:bg-red-500/20 text-red-500 rounded-full border border-red-500/20 transition-all hover:scale-110 active:scale-95"
                                     aria-label="Sign out"
-                                    title="Sign out"
+                                    title={t('nav.signOut')}
                                 >
                                     <LogOut className={ICON_CLASS.sm} />
                                 </button>
@@ -82,7 +87,7 @@ export default function Navbar() {
                             <button
                                 onClick={connect}
                                 className="flex items-center gap-2 bg-primary/10 hover:bg-primary/20 text-primary px-3 py-2 rounded-full border border-primary/20 transition-colors font-medium text-sm"
-                                aria-label="Connect wallet"
+                                aria-label={t('nav.connectWallet')}
                             >
                                 <Wallet className={ICON_CLASS.sm + " text-primary"} />
                             </button>
@@ -117,14 +122,14 @@ export default function Navbar() {
                                 className="block px-3 py-2 text-base font-medium text-muted-foreground hover:text-primary hover:bg-muted/50 rounded-lg transition-colors"
                                 onClick={() => setIsMenuOpen(false)}
                             >
-                                Markets
+                                {t('nav.markets')}
                             </Link>
                             <Link
                                 href="/create"
                                 className="block px-3 py-2 text-base font-medium text-muted-foreground hover:text-primary hover:bg-muted/50 rounded-lg transition-colors"
                                 onClick={() => setIsMenuOpen(false)}
                             >
-                                Create
+                                {t('nav.create')}
                             </Link>
                             {isConnected && (
                                 <Link
@@ -132,7 +137,7 @@ export default function Navbar() {
                                     className="block px-3 py-2 text-base font-medium text-muted-foreground hover:text-primary hover:bg-muted/50 rounded-lg transition-colors"
                                     onClick={() => setIsMenuOpen(false)}
                                 >
-                                    Transactions
+                                    {t('nav.transactions')}
                                 </Link>
                             )}
                             {isConnected && (
@@ -141,7 +146,7 @@ export default function Navbar() {
                                     className="block px-3 py-2 text-base font-medium text-muted-foreground hover:text-primary hover:bg-muted/50 rounded-lg transition-colors"
                                     onClick={() => setIsMenuOpen(false)}
                                 >
-                                    Activity
+                                    {t('nav.activity')}
                                 </Link>
                             )}
                             {isConnected && (
@@ -151,7 +156,14 @@ export default function Navbar() {
                                         className="block px-3 py-2 text-base font-medium text-muted-foreground hover:text-primary hover:bg-muted/50 rounded-lg transition-colors"
                                         onClick={() => setIsMenuOpen(false)}
                                     >
-                                        Dashboard
+                                        {t('nav.dashboard')}
+                                    </Link>
+                                    <Link
+                                        href="/settings"
+                                        className="block px-3 py-2 text-base font-medium text-muted-foreground hover:text-primary hover:bg-muted/50 rounded-lg transition-colors"
+                                        onClick={() => setIsMenuOpen(false)}
+                                    >
+                                        {t('nav.settings')}
                                     </Link>
                                     <button
                                         onClick={() => {
@@ -160,7 +172,7 @@ export default function Navbar() {
                                         }}
                                         className="w-full text-left px-3 py-2 text-base font-medium text-red-500 hover:bg-red-500/10 rounded-lg transition-colors"
                                     >
-                                        Sign Out
+                                        {t('nav.signOut')}
                                     </button>
                                 </>
                             )}
@@ -169,7 +181,7 @@ export default function Navbar() {
                                 className="block px-3 py-2 text-base font-medium text-muted-foreground hover:text-primary hover:bg-muted/50 rounded-lg transition-colors"
                                 onClick={() => setIsMenuOpen(false)}
                             >
-                                Analytics
+                                {t('nav.analytics')}
                             </Link>
                         </div>
                     </div>

--- a/web/app/components/dashboard/PlatformMetrics.tsx
+++ b/web/app/components/dashboard/PlatformMetrics.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { BarChart3, TrendingUp, Users, Target, DollarSign, Activity, Calendar, Trophy } from 'lucide-react';
+import { useMemo } from 'react';
+import { TrendingUp, Activity } from 'lucide-react';
 import { PlatformMetrics as PlatformMetricsType } from '../../lib/dashboard-types';
 import { formatCurrency, formatPercentage } from '../../lib/dashboard-utils';
+import { selectPlatformMetricCards, selectMarketDistribution, selectVolumeMetrics } from '../../lib/dashboard-selectors';
 
 interface PlatformMetricsProps {
   metrics: PlatformMetricsType;
@@ -10,6 +12,10 @@ interface PlatformMetricsProps {
 }
 
 export default function PlatformMetrics({ metrics, isLoading = false }: PlatformMetricsProps) {
+  const marketDistribution = useMemo(() => selectMarketDistribution(metrics), [metrics]);
+  const volumeMetrics = useMemo(() => selectVolumeMetrics(metrics), [metrics]);
+  const mainMetrics = useMemo(() => selectPlatformMetricCards(metrics), [metrics]);
+
   if (isLoading) {
     return (
       <div className="space-y-6">
@@ -26,53 +32,6 @@ export default function PlatformMetrics({ metrics, isLoading = false }: Platform
       </div>
     );
   }
-
-  const marketDistribution = [
-    { label: 'Active', value: metrics.activePools, color: 'text-green-500', bgColor: 'bg-green-500/10' },
-    { label: 'Settled', value: metrics.settledPools, color: 'text-blue-500', bgColor: 'bg-blue-500/10' },
-    { label: 'Expired', value: metrics.expiredPools, color: 'text-red-500', bgColor: 'bg-red-500/10' }
-  ];
-
-  const volumeMetrics = [
-    { label: 'Daily', value: metrics.dailyVolume, icon: Calendar },
-    { label: 'Weekly', value: metrics.weeklyVolume, icon: BarChart3 },
-    { label: 'Monthly', value: metrics.monthlyVolume, icon: TrendingUp }
-  ];
-
-  const mainMetrics = [
-    {
-      title: 'Total Markets',
-      value: metrics.totalPools.toString(),
-      subtitle: `${metrics.activePools} currently active`,
-      icon: Target,
-      color: 'text-blue-500',
-      bgColor: 'bg-blue-500/10'
-    },
-    {
-      title: 'Total Volume',
-      value: formatCurrency(metrics.totalVolume),
-      subtitle: `Avg: ${formatCurrency(metrics.averageMarketSize)} per market`,
-      icon: DollarSign,
-      color: 'text-green-500',
-      bgColor: 'bg-green-500/10'
-    },
-    {
-      title: 'Active Users',
-      value: metrics.totalUsers.toString(),
-      subtitle: `${metrics.totalBets} total bets placed`,
-      icon: Users,
-      color: 'text-purple-500',
-      bgColor: 'bg-purple-500/10'
-    },
-    {
-      title: 'Total Winnings',
-      value: formatCurrency(metrics.totalWinnings),
-      subtitle: `${formatPercentage((metrics.totalWinnings / Math.max(metrics.totalVolume, 1)) * 100)} of volume`,
-      icon: Trophy,
-      color: 'text-yellow-500',
-      bgColor: 'bg-yellow-500/10'
-    }
-  ];
 
   return (
     <div className="space-y-6">
@@ -98,7 +57,17 @@ export default function PlatformMetrics({ metrics, isLoading = false }: Platform
               
               <div className="space-y-1">
                 <p className="text-sm font-medium text-muted-foreground">{metric.title}</p>
-                <p className={`text-2xl font-bold ${metric.color}`}>{metric.value}</p>
+                <p className={`text-2xl font-bold ${
+                  metric.tone === 'blue'
+                    ? 'text-blue-500'
+                    : metric.tone === 'green'
+                      ? 'text-green-500'
+                      : metric.tone === 'purple'
+                        ? 'text-purple-500'
+                        : metric.tone === 'yellow'
+                          ? 'text-yellow-500'
+                          : 'text-orange-500'
+                }`}>{metric.value}</p>
                 <p className="text-xs text-muted-foreground">{metric.subtitle}</p>
               </div>
             </div>
@@ -111,21 +80,22 @@ export default function PlatformMetrics({ metrics, isLoading = false }: Platform
         <h4 className="text-lg font-semibold mb-4">Market Distribution</h4>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {marketDistribution.map((item, index) => {
-            const percentage = metrics.totalPools > 0 
-              ? (item.value / metrics.totalPools) * 100 
-              : 0;
             
             return (
               <div key={index} className="text-center">
-                <div className={`inline-flex items-center justify-center w-16 h-16 rounded-full ${item.bgColor} mb-3`}>
-                  <span className={`text-2xl font-bold ${item.color}`}>
+                <div className={`inline-flex items-center justify-center w-16 h-16 rounded-full ${
+                  item.tone === 'green' ? 'bg-green-500/10' : item.tone === 'blue' ? 'bg-blue-500/10' : 'bg-red-500/10'
+                } mb-3`}>
+                  <span className={`text-2xl font-bold ${
+                    item.tone === 'green' ? 'text-green-500' : item.tone === 'blue' ? 'text-blue-500' : 'text-red-500'
+                  }`}>
                     {item.value}
                   </span>
                 </div>
                 <div className="space-y-1">
                   <p className="font-medium">{item.label} Markets</p>
                   <p className="text-sm text-muted-foreground">
-                    {formatPercentage(percentage)} of total
+                    {formatPercentage(item.percentage)} of total
                   </p>
                 </div>
               </div>

--- a/web/app/components/dashboard/PortfolioOverview.tsx
+++ b/web/app/components/dashboard/PortfolioOverview.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { useMemo } from 'react';
 import { TrendingUp, TrendingDown, DollarSign, Target, Trophy, Activity } from 'lucide-react';
 import { UserPortfolio } from '../../lib/dashboard-types';
 import { formatCurrency, formatPercentage, formatProfitLoss } from '../../lib/dashboard-utils';
+import { selectPortfolioMetricCards } from '../../lib/dashboard-selectors';
 
 interface PortfolioOverviewProps {
   portfolio: UserPortfolio;
@@ -10,7 +12,8 @@ interface PortfolioOverviewProps {
 }
 
 export default function PortfolioOverview({ portfolio, isLoading = false }: PortfolioOverviewProps) {
-  const profitLossData = formatProfitLoss(portfolio.profitLoss);
+  const profitLossData = useMemo(() => formatProfitLoss(portfolio.profitLoss), [portfolio.profitLoss]);
+  const metrics = useMemo(() => selectPortfolioMetricCards(portfolio), [portfolio]);
 
   if (isLoading) {
     return (
@@ -46,68 +49,56 @@ export default function PortfolioOverview({ portfolio, isLoading = false }: Port
     );
   }
 
-  const metrics = [
-    {
-      title: 'Total Portfolio Value',
-      value: formatCurrency(portfolio.totalWagered + portfolio.profitLoss),
-      subtitle: `${portfolio.totalBets} total bets`,
-      icon: DollarSign,
-      color: 'text-blue-500',
-      bgColor: 'bg-blue-500/10'
-    },
-    {
-      title: 'Active Bets',
-      value: portfolio.activeBets.toString(),
-      subtitle: formatCurrency(portfolio.totalWagered - (portfolio.totalBets - portfolio.activeBets) * (portfolio.totalWagered / portfolio.totalBets)),
-      icon: Activity,
-      color: 'text-green-500',
-      bgColor: 'bg-green-500/10'
-    },
-    {
-      title: 'Total Wagered',
-      value: formatCurrency(portfolio.totalWagered),
-      subtitle: `Avg: ${formatCurrency(portfolio.totalBets > 0 ? portfolio.totalWagered / portfolio.totalBets : 0)} per bet`,
-      icon: Target,
-      color: 'text-purple-500',
-      bgColor: 'bg-purple-500/10'
-    },
-    {
-      title: 'Total Winnings',
-      value: formatCurrency(portfolio.totalWinnings),
-      subtitle: `${formatPercentage(portfolio.winRate)} win rate`,
-      icon: Trophy,
-      color: 'text-yellow-500',
-      bgColor: 'bg-yellow-500/10'
-    },
-    {
-      title: 'Claimable Amount',
-      value: formatCurrency(portfolio.totalClaimable),
-      subtitle: portfolio.totalClaimable > 0 ? 'Ready to claim' : 'No pending claims',
-      icon: DollarSign,
-      color: portfolio.totalClaimable > 0 ? 'text-green-500' : 'text-muted-foreground',
-      bgColor: portfolio.totalClaimable > 0 ? 'bg-green-500/10' : 'bg-muted/10'
-    },
-    {
-      title: 'Profit/Loss',
-      value: profitLossData.formatted,
-      subtitle: profitLossData.isBreakeven
-        ? 'Break even'
-        : profitLossData.isProfit
-          ? 'Profitable'
-          : 'In loss',
-      icon: profitLossData.isProfit ? TrendingUp : TrendingDown,
-      color: profitLossData.isBreakeven
-        ? 'text-muted-foreground'
-        : profitLossData.isProfit
-          ? 'text-green-500'
-          : 'text-red-500',
-      bgColor: profitLossData.isBreakeven
-        ? 'bg-muted/10'
-        : profitLossData.isProfit
-          ? 'bg-green-500/10'
-          : 'bg-red-500/10'
-    }
-  ];
+  const renderedMetrics = useMemo(
+    () =>
+      metrics.map((metric) => {
+        const icon =
+          metric.title === 'Total Portfolio Value'
+            ? DollarSign
+            : metric.title === 'Active Bets'
+              ? Activity
+              : metric.title === 'Total Wagered'
+                ? Target
+                : metric.title === 'Total Winnings'
+                  ? Trophy
+                  : metric.title === 'Claimable Amount'
+                    ? DollarSign
+                    : metric.title === 'Profit/Loss'
+                      ? profitLossData.isProfit
+                        ? TrendingUp
+                        : TrendingDown
+                      : DollarSign;
+
+        const color =
+          metric.tone === 'blue'
+            ? 'text-blue-500'
+            : metric.tone === 'green'
+              ? 'text-green-500'
+              : metric.tone === 'purple'
+                ? 'text-purple-500'
+                : metric.tone === 'yellow'
+                  ? 'text-yellow-500'
+                  : metric.tone === 'red'
+                    ? 'text-red-500'
+                    : 'text-muted-foreground';
+
+        const bgColor =
+          metric.tone === 'blue'
+            ? 'bg-blue-500/10'
+            : metric.tone === 'green'
+              ? 'bg-green-500/10'
+              : metric.tone === 'purple'
+                ? 'bg-purple-500/10'
+                : metric.tone === 'yellow'
+                  ? 'bg-yellow-500/10'
+                  : metric.tone === 'red'
+                    ? 'bg-red-500/10'
+                    : 'bg-muted/10';
+
+        return { ...metric, icon, color, bgColor };
+      }),
+    [metrics, profitLossData.isProfit],
+  );
 
   return (
     <div className="space-y-6">
@@ -119,7 +110,7 @@ export default function PortfolioOverview({ portfolio, isLoading = false }: Port
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {metrics.map((metric, index) => {
+        {renderedMetrics.map((metric, index) => {
           const Icon = metric.icon;
 
           return (

--- a/web/app/components/user-dashboard/DashboardConnectPrompt.tsx
+++ b/web/app/components/user-dashboard/DashboardConnectPrompt.tsx
@@ -1,11 +1,16 @@
+'use client';
+
 import { Wallet } from 'lucide-react';
+import { useI18n } from '@/app/lib/i18n';
 
 export function DashboardConnectPrompt() {
+  const { t } = useI18n();
+
   return (
     <div className="glass p-8 rounded-2xl border border-border text-center">
       <Wallet className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
-      <p className="text-lg font-bold mb-2">Connect Wallet to View Dashboard</p>
-      <p className="text-muted-foreground">Connect your wallet to see your betting history and statistics.</p>
+      <p className="text-lg font-bold mb-2">{t('dashboard.connectPromptTitle')}</p>
+      <p className="text-muted-foreground">{t('dashboard.connectPromptBody')}</p>
     </div>
   );
 }

--- a/web/app/components/user-dashboard/DashboardHeader.tsx
+++ b/web/app/components/user-dashboard/DashboardHeader.tsx
@@ -1,8 +1,14 @@
+'use client';
+
+import { useI18n } from '@/app/lib/i18n';
+
 export function DashboardHeader() {
+  const { t } = useI18n();
+
   return (
     <div className="glass p-8 rounded-2xl border border-border">
-      <h1 className="text-4xl font-bold mb-2">Dashboard</h1>
-      <p className="text-muted-foreground">Your betting statistics and activity</p>
+      <h1 className="text-4xl font-bold mb-2">{t('dashboard.title')}</h1>
+      <p className="text-muted-foreground">{t('dashboard.subtitle')}</p>
     </div>
   );
 }

--- a/web/app/components/user-dashboard/DashboardStatsSections.tsx
+++ b/web/app/components/user-dashboard/DashboardStatsSections.tsx
@@ -1,19 +1,24 @@
+'use client';
+
 import { BarChart3, Wallet, Award } from 'lucide-react';
 import type { DashboardStats } from '@/app/lib/user-dashboard/types';
 import { formatStxAmount } from '@/app/lib/user-dashboard/model';
+import { useI18n } from '@/app/lib/i18n';
 
 interface DashboardStatsSectionsProps {
   stats: DashboardStats;
 }
 
 export function DashboardStatsSections({ stats }: DashboardStatsSectionsProps) {
+  const { t } = useI18n();
+
   return (
     <>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="glass p-6 rounded-xl border border-border">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-muted-foreground">Total Bets</p>
+              <p className="text-sm text-muted-foreground">{t('dashboard.totalBets')}</p>
               <p className="text-3xl font-bold">{stats.totalBets}</p>
             </div>
             <BarChart3 className="w-8 h-8 text-primary opacity-50" />
@@ -23,7 +28,7 @@ export function DashboardStatsSections({ stats }: DashboardStatsSectionsProps) {
         <div className="glass p-6 rounded-xl border border-border">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-muted-foreground">Total Wagered</p>
+              <p className="text-sm text-muted-foreground">{t('dashboard.totalWagered')}</p>
               <p className="text-3xl font-bold">{formatStxAmount(stats.totalWagered)} STX</p>
             </div>
             <Wallet className="w-8 h-8 text-blue-500 opacity-50" />
@@ -33,7 +38,7 @@ export function DashboardStatsSections({ stats }: DashboardStatsSectionsProps) {
         <div className="glass p-6 rounded-xl border border-border">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-muted-foreground">Total Winnings</p>
+              <p className="text-sm text-muted-foreground">{t('dashboard.totalWinnings')}</p>
               <p className="text-3xl font-bold text-green-400">{formatStxAmount(stats.totalWinnings)} STX</p>
             </div>
             <Award className="w-8 h-8 text-green-500 opacity-50" />
@@ -43,7 +48,7 @@ export function DashboardStatsSections({ stats }: DashboardStatsSectionsProps) {
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="glass p-6 rounded-xl border border-border">
-          <p className="text-sm text-muted-foreground mb-2">Win Rate</p>
+          <p className="text-sm text-muted-foreground mb-2">{t('dashboard.winRate')}</p>
           <p className="text-3xl font-bold">{stats.winRate}%</p>
           <div className="mt-4 w-full bg-muted/50 rounded-full h-2">
             <div
@@ -54,12 +59,12 @@ export function DashboardStatsSections({ stats }: DashboardStatsSectionsProps) {
         </div>
 
         <div className="glass p-6 rounded-xl border border-border">
-          <p className="text-sm text-muted-foreground mb-2">Active Bets</p>
+          <p className="text-sm text-muted-foreground mb-2">{t('dashboard.activeBetsCount')}</p>
           <p className="text-3xl font-bold text-blue-400">{stats.activeBets}</p>
         </div>
 
         <div className="glass p-6 rounded-xl border border-border">
-          <p className="text-sm text-muted-foreground mb-2">Settled Bets</p>
+          <p className="text-sm text-muted-foreground mb-2">{t('dashboard.settledBetsCount')}</p>
           <p className="text-3xl font-bold text-green-400">{stats.settledBets}</p>
         </div>
       </div>

--- a/web/app/components/user-dashboard/DashboardTabBar.tsx
+++ b/web/app/components/user-dashboard/DashboardTabBar.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import { Gift } from 'lucide-react';
 import type { DashboardTabId } from '@/app/lib/user-dashboard/types';
+import { useI18n } from '@/app/lib/i18n';
 
 interface DashboardTabBarProps {
   activeTab: DashboardTabId;
@@ -7,6 +10,8 @@ interface DashboardTabBarProps {
 }
 
 export function DashboardTabBar({ activeTab, onTabChange }: DashboardTabBarProps) {
+  const { t } = useI18n();
+
   return (
     <div className="flex gap-4 border-b border-border overflow-x-auto">
       <button
@@ -18,7 +23,7 @@ export function DashboardTabBar({ activeTab, onTabChange }: DashboardTabBarProps
             : 'text-muted-foreground hover:text-foreground'
         }`}
       >
-        Overview
+        {t('dashboard.overview')}
       </button>
       <button
         type="button"
@@ -29,7 +34,7 @@ export function DashboardTabBar({ activeTab, onTabChange }: DashboardTabBarProps
             : 'text-muted-foreground hover:text-foreground'
         }`}
       >
-        Active Bets
+        {t('dashboard.activeBets')}
       </button>
       <button
         type="button"
@@ -40,7 +45,7 @@ export function DashboardTabBar({ activeTab, onTabChange }: DashboardTabBarProps
             : 'text-muted-foreground hover:text-foreground'
         }`}
       >
-        History
+        {t('dashboard.history')}
       </button>
       <button
         type="button"
@@ -52,7 +57,7 @@ export function DashboardTabBar({ activeTab, onTabChange }: DashboardTabBarProps
         }`}
       >
         <Gift className="w-4 h-4" />
-        Incentives
+        {t('dashboard.incentives')}
       </button>
     </div>
   );

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { WalletAdapterProvider } from "./components/WalletAdapterProvider";
 import { ToastProvider } from "../providers/ToastProvider";
 import { ThemeProvider } from "./context/ThemeContext";
+import { I18nProvider } from "./providers/I18nProvider";
 import Footer from "./components/Footer";
 import MarketListPreloader from "./components/MarketListPreloader";
 
@@ -55,13 +56,15 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ThemeProvider>
-          <WalletAdapterProvider>
-            <ToastProvider>
-              <MarketListPreloader />
-              {children}
-              <Footer />
-            </ToastProvider>
-          </WalletAdapterProvider>
+          <I18nProvider>
+            <WalletAdapterProvider>
+              <ToastProvider>
+                <MarketListPreloader />
+                {children}
+                <Footer />
+              </ToastProvider>
+            </WalletAdapterProvider>
+          </I18nProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/web/app/lib/dashboard-selectors.ts
+++ b/web/app/lib/dashboard-selectors.ts
@@ -1,0 +1,132 @@
+import { BarChart3, Calendar, DollarSign, Target, Trophy, TrendingUp, Users } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { PlatformMetrics, UserPortfolio } from './dashboard-types';
+import { formatCurrency, formatPercentage, formatProfitLoss } from './dashboard-utils';
+
+export interface PortfolioMetricCard {
+  title: string;
+  value: string;
+  subtitle: string;
+  tone: 'blue' | 'green' | 'yellow' | 'red' | 'muted' | 'purple';
+}
+
+export interface PlatformMetricCard {
+  title: string;
+  value: string;
+  subtitle: string;
+  tone: 'blue' | 'green' | 'purple' | 'yellow' | 'orange';
+  icon: LucideIcon;
+  color: string;
+  bgColor: string;
+}
+
+export interface PlatformDistributionItem {
+  label: string;
+  value: number;
+  percentage: number;
+  tone: 'green' | 'blue' | 'red';
+}
+
+export function selectPortfolioMetricCards(portfolio: UserPortfolio): PortfolioMetricCard[] {
+  const profitLoss = formatProfitLoss(portfolio.profitLoss);
+
+  return [
+    {
+      title: 'Total Portfolio Value',
+      value: formatCurrency(portfolio.totalWagered + portfolio.profitLoss),
+      subtitle: `${portfolio.totalBets} total bets`,
+      tone: 'blue',
+    },
+    {
+      title: 'Active Bets',
+      value: portfolio.activeBets.toString(),
+      subtitle: formatCurrency(
+        portfolio.totalBets > 0 ? portfolio.totalWagered - (portfolio.totalBets - portfolio.activeBets) * (portfolio.totalWagered / portfolio.totalBets) : 0,
+      ),
+      tone: 'green',
+    },
+    {
+      title: 'Total Wagered',
+      value: formatCurrency(portfolio.totalWagered),
+      subtitle: `Avg: ${formatCurrency(portfolio.totalBets > 0 ? portfolio.totalWagered / portfolio.totalBets : 0)} per bet`,
+      tone: 'purple',
+    },
+    {
+      title: 'Total Winnings',
+      value: formatCurrency(portfolio.totalWinnings),
+      subtitle: `${formatPercentage(portfolio.winRate)} win rate`,
+      tone: 'yellow',
+    },
+    {
+      title: 'Claimable Amount',
+      value: formatCurrency(portfolio.totalClaimable),
+      subtitle: portfolio.totalClaimable > 0 ? 'Ready to claim' : 'No pending claims',
+      tone: portfolio.totalClaimable > 0 ? 'green' : 'muted',
+    },
+    {
+      title: 'Profit/Loss',
+      value: profitLoss.formatted,
+      subtitle: profitLoss.isBreakeven ? 'Break even' : profitLoss.isProfit ? 'Profitable' : 'In loss',
+      tone: profitLoss.isBreakeven ? 'muted' : profitLoss.isProfit ? 'green' : 'red',
+    },
+  ];
+}
+
+export function selectPlatformMetricCards(metrics: PlatformMetrics) {
+  return [
+    {
+      title: 'Total Markets',
+      value: metrics.totalPools.toString(),
+      subtitle: `${metrics.activePools} currently active`,
+      tone: 'blue' as const,
+      icon: Target,
+      color: 'text-blue-500',
+      bgColor: 'bg-blue-500/10',
+    },
+    {
+      title: 'Total Volume',
+      value: formatCurrency(metrics.totalVolume),
+      subtitle: `Avg: ${formatCurrency(metrics.averageMarketSize)} per market`,
+      tone: 'green' as const,
+      icon: DollarSign,
+      color: 'text-green-500',
+      bgColor: 'bg-green-500/10',
+    },
+    {
+      title: 'Active Users',
+      value: metrics.totalUsers.toString(),
+      subtitle: `${metrics.totalBets} total bets placed`,
+      tone: 'purple' as const,
+      icon: Users,
+      color: 'text-purple-500',
+      bgColor: 'bg-purple-500/10',
+    },
+    {
+      title: 'Total Winnings',
+      value: formatCurrency(metrics.totalWinnings),
+      subtitle: `${formatPercentage((metrics.totalWinnings / Math.max(metrics.totalVolume, 1)) * 100)} of volume`,
+      tone: 'yellow' as const,
+      icon: Trophy,
+      color: 'text-yellow-500',
+      bgColor: 'bg-yellow-500/10',
+    },
+  ];
+}
+
+export function selectMarketDistribution(metrics: PlatformMetrics): PlatformDistributionItem[] {
+  const totalPools = Math.max(metrics.totalPools, 1);
+
+  return [
+    { label: 'Active', value: metrics.activePools, percentage: (metrics.activePools / totalPools) * 100, tone: 'green' },
+    { label: 'Settled', value: metrics.settledPools, percentage: (metrics.settledPools / totalPools) * 100, tone: 'blue' },
+    { label: 'Expired', value: metrics.expiredPools, percentage: (metrics.expiredPools / totalPools) * 100, tone: 'red' },
+  ];
+}
+
+export function selectVolumeMetrics(metrics: PlatformMetrics) {
+  return [
+    { label: 'Daily', value: metrics.dailyVolume, icon: Calendar },
+    { label: 'Weekly', value: metrics.weeklyVolume, icon: BarChart3 },
+    { label: 'Monthly', value: metrics.monthlyVolume, icon: TrendingUp },
+  ];
+}

--- a/web/app/lib/export.ts
+++ b/web/app/lib/export.ts
@@ -1,0 +1,65 @@
+'use client';
+
+export type ExportFormat = 'csv' | 'json';
+export type ExportRecord = Record<string, string | number | boolean | null | undefined>;
+
+function escapeCsvCell(value: string): string {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function serializeToCsv(records: ExportRecord[]): string {
+  if (records.length === 0) return '';
+
+  const headers = Array.from(
+    records.reduce((set, record) => {
+      Object.keys(record).forEach((key) => set.add(key));
+      return set;
+    }, new Set<string>()),
+  );
+
+  const rows = records.map((record) =>
+    headers
+      .map((header) => {
+        const cell = record[header];
+        if (cell === undefined || cell === null) return '';
+        return escapeCsvCell(String(cell));
+      })
+      .join(','),
+  );
+
+  return [headers.join(','), ...rows].join('\n');
+}
+
+export function downloadTextFile(filename: string, contents: string, mimeType: string): void {
+  if (typeof window === 'undefined') return;
+
+  const blob = new Blob([contents], { type: mimeType });
+  const url = window.URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  window.URL.revokeObjectURL(url);
+}
+
+export function buildExportFilename(baseName: string, format: ExportFormat): string {
+  const suffix = format === 'csv' ? 'csv' : 'json';
+  return `${baseName}-${new Date().toISOString().replace(/[:.]/g, '-')}.${suffix}`;
+}
+
+export function exportRecords(
+  records: ExportRecord[],
+  baseName: string,
+  format: ExportFormat,
+): void {
+  const filename = buildExportFilename(baseName, format);
+  if (format === 'csv') {
+    downloadTextFile(filename, serializeToCsv(records), 'text/csv;charset=utf-8');
+    return;
+  }
+
+  downloadTextFile(filename, JSON.stringify(records, null, 2), 'application/json;charset=utf-8');
+}

--- a/web/app/lib/hooks/useClaimWinnings.ts
+++ b/web/app/lib/hooks/useClaimWinnings.ts
@@ -6,6 +6,7 @@ import { predinexContract } from '../adapters/predinex-contract';
 import { invalidateOnClaimWinnings } from '../cache-invalidation';
 import { useWallet } from '../../components/WalletAdapterProvider';
 import { TxStage } from '../soroban-transaction-service';
+import { notifyBrowserEvent } from '../notifications';
 
 export type ClaimTxStatus = 'pending' | 'success' | 'failed';
 
@@ -47,6 +48,10 @@ export function useClaimWinnings(userAddress?: string | null) {
         setClaimTransactions((prev) =>
           new Map(prev).set(poolId, { status: 'success', txId: txHash })
         );
+        notifyBrowserEvent('Claim submitted', {
+          body: `Winnings claim for pool #${poolId} is being processed.`,
+          tag: `predinex-claim-${poolId}`,
+        });
         showToast('Claim submitted successfully!', 'success');
         onSuccess?.();
       } catch (error) {

--- a/web/app/lib/hooks/useDashboardData.ts
+++ b/web/app/lib/hooks/useDashboardData.ts
@@ -5,6 +5,7 @@ import { DashboardData, DashboardFilters, ClaimTransaction } from '../dashboard-
 import { fetchDashboardData, claimWinnings } from '../dashboard-api';
 import { invalidateOnClaimWinnings } from '../cache-invalidation';
 import { useVisibilityAwarePolling } from './useVisibilityAwarePolling';
+import { notifyBrowserEvent } from '../notifications';
 
 interface UseDashboardDataState {
   // Data
@@ -56,6 +57,7 @@ export function useDashboardData(userAddress: string | null): UseDashboardDataSt
   const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const retryCountRef = useRef(0);
   const isMountedRef = useRef(true);
+  const previousDataRef = useRef<DashboardData | null>(null);
 
   // Fetch dashboard data
   const fetchData = useCallback(async (showLoading: boolean = true) => {
@@ -75,9 +77,35 @@ export function useDashboardData(userAddress: string | null): UseDashboardDataSt
       const dashboardData = await fetchDashboardData(userAddress);
       
       if (isMountedRef.current) {
+        const previousData = previousDataRef.current;
         setData(dashboardData);
         setIsConnected(true);
         retryCountRef.current = 0;
+
+        if (previousData) {
+          if (dashboardData.userPortfolio.totalClaimable > previousData.userPortfolio.totalClaimable) {
+            notifyBrowserEvent('Payout available', {
+              body: `${dashboardData.userPortfolio.totalClaimable.toFixed(2)} STX is claimable.`,
+              tag: 'predinex-payout-available',
+            });
+          }
+
+          if (dashboardData.activeBets.length > previousData.activeBets.length) {
+            notifyBrowserEvent('Active bets updated', {
+              body: 'Your dashboard has new active positions.',
+              tag: 'predinex-active-bets-update',
+            });
+          }
+
+          if (dashboardData.userPortfolio.totalWinnings > previousData.userPortfolio.totalWinnings) {
+            notifyBrowserEvent('Bet resolved', {
+              body: 'A position settled in your favor.',
+              tag: 'predinex-bet-resolved',
+            });
+          }
+        }
+
+        previousDataRef.current = dashboardData;
       }
     } catch (err) {
       console.error('Failed to fetch dashboard data:', err);
@@ -195,6 +223,7 @@ export function useDashboardData(userAddress: string | null): UseDashboardDataSt
       setData(null);
       setError(null);
       setClaimTransactions(new Map());
+      previousDataRef.current = null;
       retryCountRef.current = 0;
     }
   }, [userAddress]);

--- a/web/app/lib/i18n.tsx
+++ b/web/app/lib/i18n.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo } from 'react';
+import { useLocalStorage } from './hooks/useLocalStorage';
+
+export type AppLanguage = 'en' | 'es' | 'fr';
+
+type TranslationMap = Record<string, string>;
+
+const translations: Record<AppLanguage, TranslationMap> = {
+  en: {
+    'nav.markets': 'Markets',
+    'nav.create': 'Create',
+    'nav.transactions': 'Transactions',
+    'nav.activity': 'Activity',
+    'nav.dashboard': 'Dashboard',
+    'nav.analytics': 'Analytics',
+    'nav.settings': 'Settings',
+    'nav.connectWallet': 'Connect wallet',
+    'nav.signOut': 'Sign out',
+    'dashboard.title': 'Dashboard',
+    'dashboard.subtitle': 'Your betting statistics and activity',
+    'dashboard.connectPromptTitle': 'Connect Wallet to View Dashboard',
+    'dashboard.connectPromptBody': 'Connect your wallet to see your betting history and statistics.',
+    'dashboard.refresh': 'Refresh Data',
+    'dashboard.refreshing': 'Refreshing...',
+    'dashboard.overview': 'Overview',
+    'dashboard.activeBets': 'Active Bets',
+    'dashboard.history': 'History',
+    'dashboard.incentives': 'Incentives',
+    'dashboard.recentActivity': 'Recent Activity',
+    'dashboard.noBets': 'No bets yet. Start betting to see your activity here.',
+    'dashboard.noActiveBets': 'No active bets.',
+    'dashboard.noHistory': 'No history yet.',
+    'dashboard.totalBets': 'Total Bets',
+    'dashboard.totalWagered': 'Total Wagered',
+    'dashboard.totalWinnings': 'Total Winnings',
+    'dashboard.winRate': 'Win Rate',
+    'dashboard.activeBetsCount': 'Active Bets',
+    'dashboard.settledBetsCount': 'Settled Bets',
+    'settings.title': 'Settings',
+    'settings.subtitle': 'Personalize language, notifications, and exports.',
+    'settings.language': 'Language',
+    'settings.languageBody': 'Choose the interface language used across the app.',
+    'settings.notifications': 'Push notifications',
+    'settings.notificationsBody': 'Get browser alerts for claims, bet updates, and pool changes.',
+    'settings.notificationsOn': 'Enabled',
+    'settings.notificationsOff': 'Disabled',
+    'settings.requestPermission': 'Enable notifications',
+    'settings.testNotification': 'Send test notification',
+    'settings.exportTitle': 'Exports',
+    'settings.exportBody': 'Download pools and activity data in CSV or JSON.',
+    'settings.exportPoolsCsv': 'Export pools CSV',
+    'settings.exportPoolsJson': 'Export pools JSON',
+    'settings.exportActivityCsv': 'Export activity CSV',
+    'settings.exportActivityJson': 'Export activity JSON',
+    'settings.loadingData': 'Loading data...',
+    'settings.noWallet': 'Connect a wallet to export personal activity.',
+    'settings.exportComplete': 'Export ready',
+    'settings.exportFailed': 'Export failed',
+    'settings.permissionGranted': 'Notification permission granted',
+    'settings.permissionDenied': 'Notification permission denied',
+  },
+  es: {
+    'nav.markets': 'Mercados',
+    'nav.create': 'Crear',
+    'nav.transactions': 'Transacciones',
+    'nav.activity': 'Actividad',
+    'nav.dashboard': 'Panel',
+    'nav.analytics': 'Analíticas',
+    'nav.settings': 'Ajustes',
+    'nav.connectWallet': 'Conectar cartera',
+    'nav.signOut': 'Cerrar sesión',
+    'dashboard.title': 'Panel',
+    'dashboard.subtitle': 'Tus estadísticas y actividad de apuestas',
+    'dashboard.connectPromptTitle': 'Conecta la cartera para ver el panel',
+    'dashboard.connectPromptBody': 'Conecta tu cartera para ver tu historial y estadísticas.',
+    'dashboard.refresh': 'Actualizar datos',
+    'dashboard.refreshing': 'Actualizando...',
+    'dashboard.overview': 'Resumen',
+    'dashboard.activeBets': 'Apuestas activas',
+    'dashboard.history': 'Historial',
+    'dashboard.incentives': 'Incentivos',
+    'dashboard.recentActivity': 'Actividad reciente',
+    'dashboard.noBets': 'Aún no hay apuestas. Empieza a apostar para ver tu actividad aquí.',
+    'dashboard.noActiveBets': 'No hay apuestas activas.',
+    'dashboard.noHistory': 'Todavía no hay historial.',
+    'dashboard.totalBets': 'Apuestas totales',
+    'dashboard.totalWagered': 'Total apostado',
+    'dashboard.totalWinnings': 'Ganancias totales',
+    'dashboard.winRate': 'Tasa de acierto',
+    'dashboard.activeBetsCount': 'Apuestas activas',
+    'dashboard.settledBetsCount': 'Apuestas liquidadas',
+    'settings.title': 'Ajustes',
+    'settings.subtitle': 'Personaliza idioma, notificaciones y exportaciones.',
+    'settings.language': 'Idioma',
+    'settings.languageBody': 'Elige el idioma de la interfaz en toda la app.',
+    'settings.notifications': 'Notificaciones push',
+    'settings.notificationsBody': 'Recibe alertas del navegador para cobros, apuestas y cambios de mercado.',
+    'settings.notificationsOn': 'Activadas',
+    'settings.notificationsOff': 'Desactivadas',
+    'settings.requestPermission': 'Activar notificaciones',
+    'settings.testNotification': 'Enviar notificación de prueba',
+    'settings.exportTitle': 'Exportaciones',
+    'settings.exportBody': 'Descarga datos de mercados y actividad en CSV o JSON.',
+    'settings.exportPoolsCsv': 'Exportar mercados CSV',
+    'settings.exportPoolsJson': 'Exportar mercados JSON',
+    'settings.exportActivityCsv': 'Exportar actividad CSV',
+    'settings.exportActivityJson': 'Exportar actividad JSON',
+    'settings.loadingData': 'Cargando datos...',
+    'settings.noWallet': 'Conecta una cartera para exportar actividad personal.',
+    'settings.exportComplete': 'Exportación lista',
+    'settings.exportFailed': 'La exportación falló',
+    'settings.permissionGranted': 'Permiso de notificaciones concedido',
+    'settings.permissionDenied': 'Permiso de notificaciones denegado',
+  },
+  fr: {
+    'nav.markets': 'Marchés',
+    'nav.create': 'Créer',
+    'nav.transactions': 'Transactions',
+    'nav.activity': 'Activité',
+    'nav.dashboard': 'Tableau de bord',
+    'nav.analytics': 'Analytique',
+    'nav.settings': 'Paramètres',
+    'nav.connectWallet': 'Connecter le wallet',
+    'nav.signOut': 'Déconnexion',
+    'dashboard.title': 'Tableau de bord',
+    'dashboard.subtitle': 'Vos statistiques et votre activité de paris',
+    'dashboard.connectPromptTitle': 'Connectez le wallet pour voir le tableau de bord',
+    'dashboard.connectPromptBody': 'Connectez votre wallet pour voir votre historique et vos statistiques.',
+    'dashboard.refresh': 'Actualiser',
+    'dashboard.refreshing': 'Actualisation...',
+    'dashboard.overview': 'Aperçu',
+    'dashboard.activeBets': 'Paris actifs',
+    'dashboard.history': 'Historique',
+    'dashboard.incentives': 'Incitations',
+    'dashboard.recentActivity': 'Activité récente',
+    'dashboard.noBets': 'Aucun pari pour le moment. Commencez à parier pour voir votre activité ici.',
+    'dashboard.noActiveBets': 'Aucun pari actif.',
+    'dashboard.noHistory': "Pas d'historique pour le moment.",
+    'dashboard.totalBets': 'Paris totaux',
+    'dashboard.totalWagered': 'Total misé',
+    'dashboard.totalWinnings': 'Gains totaux',
+    'dashboard.winRate': 'Taux de victoire',
+    'dashboard.activeBetsCount': 'Paris actifs',
+    'dashboard.settledBetsCount': 'Paris réglés',
+    'settings.title': 'Paramètres',
+    'settings.subtitle': 'Personnalisez la langue, les notifications et les exports.',
+    'settings.language': 'Langue',
+    'settings.languageBody': "Choisissez la langue de l'interface dans l'application.",
+    'settings.notifications': 'Notifications push',
+    'settings.notificationsBody': 'Recevez des alertes navigateur pour les gains, mises à jour et changements de marché.',
+    'settings.notificationsOn': 'Activées',
+    'settings.notificationsOff': 'Désactivées',
+    'settings.requestPermission': 'Activer les notifications',
+    'settings.testNotification': 'Envoyer une notification test',
+    'settings.exportTitle': 'Exports',
+    'settings.exportBody': 'Téléchargez les données des marchés et de l’activité en CSV ou JSON.',
+    'settings.exportPoolsCsv': 'Exporter les marchés CSV',
+    'settings.exportPoolsJson': 'Exporter les marchés JSON',
+    'settings.exportActivityCsv': 'Exporter l’activité CSV',
+    'settings.exportActivityJson': 'Exporter l’activité JSON',
+    'settings.loadingData': 'Chargement des données...',
+    'settings.noWallet': 'Connectez un wallet pour exporter votre activité personnelle.',
+    'settings.exportComplete': 'Export prêt',
+    'settings.exportFailed': "L'export a échoué",
+    'settings.permissionGranted': 'Autorisation des notifications accordée',
+    'settings.permissionDenied': 'Autorisation des notifications refusée',
+  },
+};
+
+export const supportedLanguages: Array<{ code: AppLanguage; label: string }> = [
+  { code: 'en', label: 'English' },
+  { code: 'es', label: 'Español' },
+  { code: 'fr', label: 'Français' },
+];
+
+export interface I18nContextValue {
+  language: AppLanguage;
+  setLanguage: (language: AppLanguage) => void;
+  t: (key: keyof typeof translations.en, fallback?: string) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+const STORAGE_KEY = 'predinex_language_v1';
+
+export function I18nProvider({ children }: { children: React.ReactNode }) {
+  const [language, setLanguage] = useLocalStorage<AppLanguage>(STORAGE_KEY, 'en');
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = language;
+    }
+  }, [language]);
+
+  const t = useCallback(
+    (key: keyof typeof translations.en, fallback?: string) => translations[language][key] ?? translations.en[key] ?? fallback ?? key,
+    [language],
+  );
+
+  const value = useMemo<I18nContextValue>(
+    () => ({
+      language,
+      setLanguage,
+      t,
+    }),
+    [language, setLanguage, t],
+  );
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n(): I18nContextValue {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error('useI18n must be used within an I18nProvider');
+  }
+  return context;
+}

--- a/web/app/lib/notifications.ts
+++ b/web/app/lib/notifications.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useLocalStorage } from './hooks/useLocalStorage';
+
+const STORAGE_KEY = 'predinex_push_notifications_v1';
+
+export type BrowserNotificationPermission = 'default' | 'granted' | 'denied';
+
+export interface BrowserNotificationOptions {
+  body?: string;
+  tag?: string;
+  icon?: string;
+}
+
+function isNotificationSupported(): boolean {
+  return typeof window !== 'undefined' && 'Notification' in window;
+}
+
+function getPermission(): BrowserNotificationPermission {
+  if (!isNotificationSupported()) return 'denied';
+  return window.Notification.permission as BrowserNotificationPermission;
+}
+
+export function isBrowserNotificationEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.localStorage.getItem(STORAGE_KEY) === 'true';
+}
+
+export function setBrowserNotificationEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, String(enabled));
+}
+
+export function notifyBrowserEvent(title: string, options: BrowserNotificationOptions = {}): boolean {
+  if (!isNotificationSupported() || !isBrowserNotificationEnabled() || getPermission() !== 'granted') {
+    return false;
+  }
+
+  new window.Notification(title, options);
+  return true;
+}
+
+export function useBrowserNotifications() {
+  const [enabled, setEnabledState, clearEnabled] = useLocalStorage<boolean>(STORAGE_KEY, false);
+  const [permission, setPermission] = useState<BrowserNotificationPermission>('default');
+
+  useEffect(() => {
+    setPermission(getPermission());
+  }, []);
+
+  const requestPermission = async () => {
+    if (!isNotificationSupported()) {
+      return 'denied' as const;
+    }
+
+    const nextPermission = (await window.Notification.requestPermission()) as BrowserNotificationPermission;
+    setPermission(nextPermission);
+    if (nextPermission === 'granted') {
+      setEnabledState(true);
+    }
+    return nextPermission;
+  };
+
+  const disable = () => {
+    clearEnabled();
+    setPermission(getPermission());
+  };
+
+  const sendTestNotification = async () => {
+    const nextPermission = permission === 'granted' ? permission : await requestPermission();
+    if (nextPermission === 'granted') {
+      notifyBrowserEvent('Predinex alerts are enabled', {
+        body: 'You will receive browser notifications for important market events.',
+        tag: 'predinex-test-notification',
+      });
+    }
+  };
+
+  return useMemo(
+    () => ({
+      enabled,
+      permission,
+      setEnabled: (nextEnabled: boolean) => {
+        setEnabledState(nextEnabled);
+        if (nextEnabled && permission !== 'granted') {
+          void requestPermission();
+        }
+      },
+      requestPermission,
+      disable,
+      sendTestNotification,
+    }),
+    [disable, enabled, permission, requestPermission, sendTestNotification, setEnabledState],
+  );
+}

--- a/web/app/providers/I18nProvider.tsx
+++ b/web/app/providers/I18nProvider.tsx
@@ -1,0 +1,3 @@
+'use client';
+
+export { I18nProvider } from '../lib/i18n';

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useEffect, useMemo, useState, type ElementType, type ReactNode } from 'react';
+import Navbar from '../components/Navbar';
+import { useWallet } from '../components/WalletAdapterProvider';
+import { getMarkets, getUserActivity, type Pool, type ActivityItem } from '../lib/stacks-api';
+import { useI18n, supportedLanguages, type AppLanguage } from '../lib/i18n';
+import { useBrowserNotifications } from '../lib/notifications';
+import { exportRecords } from '../lib/export';
+import { Bell, Download, Languages, LoaderCircle, FileDown, Globe2 } from 'lucide-react';
+
+function StatPill({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-xl border border-border bg-card/40 px-4 py-3">
+      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function SettingsCard({
+  icon: Icon,
+  title,
+  body,
+  children,
+}: {
+  icon: ElementType;
+  title: string;
+  body: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="glass rounded-2xl border border-border p-6 space-y-5">
+      <div className="flex items-start gap-4">
+        <div className="rounded-xl bg-primary/10 p-3">
+          <Icon className="h-5 w-5 text-primary" />
+        </div>
+        <div>
+          <h2 className="text-xl font-semibold">{title}</h2>
+          <p className="text-sm text-muted-foreground">{body}</p>
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export default function SettingsPage() {
+  const { address, isConnected } = useWallet();
+  const { language, setLanguage, t } = useI18n();
+  const notifications = useBrowserNotifications();
+  const [pools, setPools] = useState<Pool[]>([]);
+  const [activity, setActivity] = useState<ActivityItem[]>([]);
+  const [isLoadingData, setIsLoadingData] = useState(true);
+  const [isExporting, setIsExporting] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadExportData() {
+      setIsLoadingData(true);
+
+      try {
+        const [marketData, activityData] = await Promise.all([
+          getMarkets('all'),
+          address ? getUserActivity(address, 25) : Promise.resolve([]),
+        ]);
+
+        if (!active) return;
+        setPools(marketData);
+        setActivity(activityData);
+      } finally {
+        if (active) {
+          setIsLoadingData(false);
+        }
+      }
+    }
+
+    void loadExportData();
+
+    return () => {
+      active = false;
+    };
+  }, [address]);
+
+  const poolExportRows = useMemo(
+    () =>
+      pools.map((pool) => ({
+        poolId: pool.id,
+        title: pool.title,
+        status: pool.status,
+        totalA: pool.totalA,
+        totalB: pool.totalB,
+        totalVolume: pool.totalA + pool.totalB,
+        creator: pool.creator,
+        expiry: pool.expiry,
+      })),
+    [pools],
+  );
+
+  const activityExportRows = useMemo(
+    () =>
+      activity.map((item) => ({
+        txId: item.txId,
+        type: item.type,
+        functionName: item.functionName,
+        status: item.status,
+        timestamp: new Date(item.timestamp * 1000).toISOString(),
+        poolId: item.poolId ?? '',
+        poolTitle: item.poolTitle ?? '',
+        amount: item.amount ?? '',
+      })),
+    [activity],
+  );
+
+  const handleExport = async (kind: 'pools-csv' | 'pools-json' | 'activity-csv' | 'activity-json') => {
+    setIsExporting(kind);
+    try {
+      switch (kind) {
+        case 'pools-csv':
+          exportRecords(poolExportRows, 'predinex-pools', 'csv');
+          break;
+        case 'pools-json':
+          exportRecords(poolExportRows, 'predinex-pools', 'json');
+          break;
+        case 'activity-csv':
+          exportRecords(activityExportRows, 'predinex-activity', 'csv');
+          break;
+        case 'activity-json':
+          exportRecords(activityExportRows, 'predinex-activity', 'json');
+          break;
+      }
+    } finally {
+      setIsExporting(null);
+    }
+  };
+
+  const requestNotifications = async () => {
+    const permission = await notifications.requestPermission();
+    if (permission === 'granted') {
+      notifications.sendTestNotification();
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <Navbar />
+
+      <div className="mx-auto max-w-7xl px-4 pb-16 pt-24 sm:px-6 lg:px-8">
+        <div className="mb-8 flex flex-col gap-3">
+          <div className="inline-flex items-center gap-2 text-sm font-medium text-primary">
+            <Globe2 className="h-4 w-4" />
+            {t('settings.title')}
+          </div>
+          <h1 className="text-4xl font-black tracking-tight">{t('settings.title')}</h1>
+          <p className="max-w-2xl text-muted-foreground">{t('settings.subtitle')}</p>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          <SettingsCard icon={Languages} title={t('settings.language')} body={t('settings.languageBody')}>
+            <div className="space-y-4">
+              <label className="block text-sm font-medium text-muted-foreground" htmlFor="language">
+                {t('settings.language')}
+              </label>
+              <select
+                id="language"
+                value={language}
+                onChange={(e) => setLanguage(e.target.value as AppLanguage)}
+                className="w-full rounded-xl border border-border bg-background px-4 py-3 text-sm"
+              >
+                {supportedLanguages.map((option) => (
+                  <option key={option.code} value={option.code}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </SettingsCard>
+
+          <SettingsCard icon={Bell} title={t('settings.notifications')} body={t('settings.notificationsBody')}>
+            <div className="space-y-4">
+              <div className="flex items-center justify-between rounded-xl border border-border bg-card/40 px-4 py-3">
+                <div>
+                  <p className="font-medium">
+                    {notifications.enabled ? t('settings.notificationsOn') : t('settings.notificationsOff')}
+                  </p>
+                  <p className="text-xs text-muted-foreground">{notifications.permission}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => notifications.setEnabled(!notifications.enabled)}
+                  className={`rounded-full px-4 py-2 text-sm font-semibold transition-colors ${
+                    notifications.enabled ? 'bg-green-500/15 text-green-400' : 'bg-muted/50 text-muted-foreground'
+                  }`}
+                >
+                  {notifications.enabled ? 'On' : 'Off'}
+                </button>
+              </div>
+
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <button
+                  type="button"
+                  onClick={() => void requestNotifications()}
+                  className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl bg-primary px-4 py-3 font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+                >
+                  {t('settings.requestPermission')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void notifications.sendTestNotification()}
+                  className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl border border-border bg-card/40 px-4 py-3 font-semibold transition-colors hover:bg-card"
+                >
+                  <Bell className="h-4 w-4" />
+                  {t('settings.testNotification')}
+                </button>
+              </div>
+            </div>
+          </SettingsCard>
+
+          <SettingsCard icon={Download} title={t('settings.exportTitle')} body={t('settings.exportBody')}>
+            <div className="grid grid-cols-2 gap-3">
+              <button
+                type="button"
+                disabled={isLoadingData || isExporting !== null}
+                onClick={() => void handleExport('pools-csv')}
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-border bg-card/40 px-4 py-3 text-sm font-semibold transition-colors hover:bg-card disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isExporting === 'pools-csv' ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <FileDown className="h-4 w-4" />}
+                {t('settings.exportPoolsCsv')}
+              </button>
+              <button
+                type="button"
+                disabled={isLoadingData || isExporting !== null}
+                onClick={() => void handleExport('pools-json')}
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-border bg-card/40 px-4 py-3 text-sm font-semibold transition-colors hover:bg-card disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isExporting === 'pools-json' ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <FileDown className="h-4 w-4" />}
+                {t('settings.exportPoolsJson')}
+              </button>
+              <button
+                type="button"
+                disabled={!isConnected || isLoadingData || isExporting !== null}
+                onClick={() => void handleExport('activity-csv')}
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-border bg-card/40 px-4 py-3 text-sm font-semibold transition-colors hover:bg-card disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isExporting === 'activity-csv' ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <FileDown className="h-4 w-4" />}
+                {t('settings.exportActivityCsv')}
+              </button>
+              <button
+                type="button"
+                disabled={!isConnected || isLoadingData || isExporting !== null}
+                onClick={() => void handleExport('activity-json')}
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-border bg-card/40 px-4 py-3 text-sm font-semibold transition-colors hover:bg-card disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isExporting === 'activity-json' ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <FileDown className="h-4 w-4" />}
+                {t('settings.exportActivityJson')}
+              </button>
+            </div>
+
+            <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <StatPill label="Markets" value={pools.length} />
+              <StatPill label="Activity" value={activity.length} />
+              <StatPill label="Wallet" value={isConnected ? 'Connected' : 'Disconnected'} />
+              <StatPill label="Data" value={isLoadingData ? t('settings.loadingData') : 'Ready'} />
+            </div>
+
+            {!isConnected && <p className="text-sm text-muted-foreground">{t('settings.noWallet')}</p>}
+          </SettingsCard>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/app/transactions/page.tsx
+++ b/web/app/transactions/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { ArrowUpRight, ArrowDownLeft, Shield } from 'lucide-react';
 import { ICON_CLASS } from '../lib/constants';
+import { exportRecords } from '../lib/export';
 
 interface Transaction {
   id: string;
@@ -102,12 +103,40 @@ export default function TransactionsPage() {
     }
   };
 
+  const transactionExportRows = filteredTransactions.map((tx) => ({
+    id: tx.id,
+    type: tx.type,
+    description: tx.description,
+    amount: tx.amount,
+    date: tx.date.toISOString(),
+    status: tx.status,
+    hash: tx.hash ?? '',
+  }));
+
   return (
     <main className="min-h-screen pt-24 pb-16 px-4">
       <div className="max-w-6xl mx-auto">
-        <div className="mb-8">
+        <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
           <h1 className="text-4xl font-bold mb-2">Transaction History</h1>
           <p className="text-muted-foreground">View all your pool creations, bets, settlements, and payouts</p>
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => exportRecords(transactionExportRows, 'predinex-transactions', 'csv')}
+              className="rounded-xl border border-border bg-card/40 px-4 py-3 text-sm font-semibold transition-colors hover:bg-card"
+            >
+              Export CSV
+            </button>
+            <button
+              type="button"
+              onClick={() => exportRecords(transactionExportRows, 'predinex-transactions', 'json')}
+              className="rounded-xl border border-border bg-card/40 px-4 py-3 text-sm font-semibold transition-colors hover:bg-card"
+            >
+              Export JSON
+            </button>
+          </div>
         </div>
 
         {/* Filters */}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -41,25 +41,16 @@
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^5.1.2",
         "@vitest/ui": "^3.2.4",
+        "callsites": "^3.1.0",
         "eslint": "^9",
         "eslint-config-next": "16.0.8",
-        "callsites": "^3.1.0",
-        "typescript-eslint": "^8.49.0",
         "fast-check": "^4.5.2",
         "jsdom": "^27.0.1",
         "pino-pretty": "^13.1.3",
         "tailwindcss": "^4",
         "typescript": "^5",
+        "typescript-eslint": "^8.49.0",
         "vitest": "^3.2.4"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4608,8 +4599,8 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.49.0",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.49.0",
@@ -4635,8 +4626,8 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.5",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -4645,8 +4636,8 @@
       "version": "8.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
@@ -4671,8 +4662,8 @@
       "version": "8.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
       "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.59.1",
@@ -4694,8 +4685,8 @@
       "version": "8.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
       "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.59.1",
@@ -4713,8 +4704,8 @@
       "version": "8.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
       "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4731,8 +4722,8 @@
       "version": "8.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
       "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4746,8 +4737,8 @@
       "version": "8.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
       "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@typescript-eslint/project-service": "8.59.1",
@@ -4775,8 +4766,8 @@
       "version": "8.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
       "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.59.1",
@@ -4794,8 +4785,8 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4805,8 +4796,8 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4819,8 +4810,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -4833,8 +4824,8 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -4850,8 +4841,8 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "peer": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4862,8 +4853,8 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.49.0",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.49.0",
         "@typescript-eslint/types": "^8.49.0",
@@ -4882,8 +4873,8 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.49.0",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@typescript-eslint/types": "8.49.0",
         "@typescript-eslint/visitor-keys": "8.49.0"
@@ -4898,8 +4889,8 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.49.0",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4913,8 +4904,8 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.49.0",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@typescript-eslint/types": "8.49.0",
         "@typescript-eslint/typescript-estree": "8.49.0",
@@ -4936,8 +4927,8 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.49.0",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4948,8 +4939,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.49.0",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@typescript-eslint/project-service": "8.49.0",
         "@typescript-eslint/tsconfig-utils": "8.49.0",
@@ -4974,16 +4965,16 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
       "version": "2.0.2",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "9.0.5",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4996,8 +4987,8 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.49.0",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.49.0",
@@ -5018,8 +5009,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.49.0",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@typescript-eslint/types": "8.49.0",
         "eslint-visitor-keys": "^4.2.1"
@@ -6604,6 +6595,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase": {
@@ -8226,6 +8226,7 @@
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.0.1",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/parser": "^7.24.4",
@@ -8245,6 +8246,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -8252,6 +8254,7 @@
     "node_modules/eslint-plugin-react-hooks/node_modules/zod-validation-error": {
       "version": "4.0.2",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8679,7 +8682,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9607,7 +9609,7 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -13285,8 +13287,8 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18.12"
       },
@@ -13437,6 +13439,7 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.49.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.49.0",
@@ -13460,8 +13463,8 @@
       "version": "8.49.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.49.0.tgz",
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",


### PR DESCRIPTION
Adds a shared client-side i18n layer, a settings page for language and browser notifications, export actions for pools and activity, and memoized dashboard metric selectors.

Closes #318
Closes #321
Closes #324
Closes #75